### PR TITLE
fix use gloo backend

### DIFF
--- a/csrc/torch/CMakeLists.txt
+++ b/csrc/torch/CMakeLists.txt
@@ -8,7 +8,7 @@ set(PYTHON_SUPPORTED_VERSIONS "3.8" "3.9" "3.10" "3.11" "3.12")
 
 if (USE_GLOO_BACKEND)
     set(BACKEND_SRC gloo_backend.cpp)
-    set(ENGINE_LIBRARIES _slime_gloo)
+    set(ENGINE_LIBRARIES _slime_gloo _slime_utils)
 else ()
     set(BACKEND_SRC slime_backend.cpp)
     set(ENGINE_LIBRARIES _slime_utils _slime_engine _slime_rdma)


### PR DESCRIPTION
fix use gloo backend

``` shell
 torchrun \
    --nproc-per-node 2 \
    --nnodes=1 \
    --node_rank=0 --master-addr 127.0.0.1 \
    --master_port=6007 \
    bench/python/sendrecv_bench.py --num-concurrency 8
```

``` python
Benchmark Results:
+------------------------+---------------------------+---------------+---------------+
|   Message Size (bytes) |   Total Transport (bytes) | Avg Latency   | Bandwidth     |
+========================+===========================+===============+===============+
|                   2048 |                     16384 | 92.29 ms      | 2.22 MB/s     |
+------------------------+---------------------------+---------------+---------------+
|                   4096 |                     32768 | 92.34 ms      | 4.44 MB/s     |
+------------------------+---------------------------+---------------+---------------+
|                   8192 |                     65536 | 84.27 ms      | 9.72 MB/s     |
+------------------------+---------------------------+---------------+---------------+
|                  16384 |                    131072 | 84.76 ms      | 19.33 MB/s    |
+------------------------+---------------------------+---------------+---------------+
|                  32768 |                    262144 | 100.18 ms     | 32.71 MB/s    |
+------------------------+---------------------------+---------------+---------------+
|                  65536 |                    524288 | 76.16 ms      | 86.05 MB/s    |
+------------------------+---------------------------+---------------+---------------+
|                 131072 |                   1048576 | 72.71 ms      | 180.28 MB/s   |
+------------------------+---------------------------+---------------+---------------+
|                 262144 |                   2097152 | 105.09 ms     | 249.46 MB/s   |
+------------------------+---------------------------+---------------+---------------+
|                 524288 |                   4194304 | 77.72 ms      | 674.55 MB/s   |
+------------------------+---------------------------+---------------+---------------+
|                1048576 |                   8388608 | 74.81 ms      | 1401.60 MB/s  |
+------------------------+---------------------------+---------------+---------------+
|                2097152 |                  16777216 | 104.62 ms     | 2004.54 MB/s  |
+------------------------+---------------------------+---------------+---------------+
|                4194304 |                  33554432 | 80.56 ms      | 5206.43 MB/s  |
+------------------------+---------------------------+---------------+---------------+
|                8388608 |                  67108864 | 124.21 ms     | 6753.66 MB/s  |
+------------------------+---------------------------+---------------+---------------+
|               16777216 |                 134217728 | 122.72 ms     | 13671.10 MB/s |
+------------------------+---------------------------+---------------+---------------+
|               33554432 |                 268435456 | 193.97 ms     | 17298.86 MB/s |
+------------------------+---------------------------+---------------+---------------+
|               67108864 |                 536870912 | 341.11 ms     | 19673.91 MB/s |
+------------------------+---------------------------+---------------+---------------+
|              134217728 |                1073741824 | 640.73 ms     | 20947.55 MB/s |
+------------------------+---------------------------+---------------+---------------+
```