### PR TITLE
code refactor

### DIFF
--- a/csrc/engine/rdma/memory_pool.cpp
+++ b/csrc/engine/rdma/memory_pool.cpp
@@ -22,7 +22,7 @@ int RDMAMemoryPool::register_memory_region(const std::string& mr_key, uintptr_t 
 
     SLIME_ASSERT(mr, " Failed to register memory " << data_ptr);
 
-    SLIME_LOG_DEBUG("Memory region: " << (void*)data_ptr << " -- " << (void*)(data_ptr + length)
+    SLIME_LOG_DEBUG("Memory region: " << mr_key << ", " << (void*)data_ptr << " -- " << (void*)(data_ptr + length)
                                       << ", Device name: " << pd_->context->device->dev_name << ", Length: " << length
                                       << " (" << length / 1024 / 1024 << " MB)"
                                       << ", Permission: " << access_rights << ", LKey: " << mr->lkey
@@ -47,6 +47,7 @@ int RDMAMemoryPool::register_remote_memory_region(const std::string& mr_key,
 {
     std::unique_lock<std::mutex> lock(remote_mrs_mutex_);
     remote_mrs_[mr_key] = remote_mr_t(addr, length, rkey);
+    SLIME_LOG_DEBUG("Remote memory region registered: " << mr_key << ", " << addr << ", " << length << ", " << rkey << ".");
     return 0;
 }
 
@@ -55,6 +56,7 @@ int RDMAMemoryPool::register_remote_memory_region(const std::string& mr_key, con
     std::unique_lock<std::mutex> lock(remote_mrs_mutex_);
     remote_mrs_[mr_key] =
         remote_mr_t(mr_info["addr"].get<uintptr_t>(), mr_info["length"].get<size_t>(), mr_info["rkey"].get<uint32_t>());
+    SLIME_LOG_DEBUG("Remote memory region registered: " << mr_key << ", " << mr_info << ".");
     return 0;
 }
 

--- a/csrc/engine/rdma/rdma_buffer.cpp
+++ b/csrc/engine/rdma/rdma_buffer.cpp
@@ -5,27 +5,26 @@ namespace slime {
 
 void RDMABuffer::send()
 {
-    send_pending_   = true;
-    send_completed_ = false;
-
-    end_point_->addSendTask(data_info, [this]() {
-        std::unique_lock<std::mutex> lock(send_mutex_);
-        send_completed_ = true;
-        send_pending_   = false;
-        send_cv_.notify_all();
-    });
+    endpoint_->addSendTask(shared_from_this());
 }
 
 void RDMABuffer::recv()
 {
-    recv_pending_   = true;
-    recv_completed_ = false;
-    end_point_->addRecvTask(data_info, [this]() {
-        std::unique_lock<std::mutex> lock(recv_mutex_);
-        recv_completed_ = true;
-        recv_pending_   = false;
-        recv_cv_.notify_all();
-    });
+    endpoint_->addRecvTask(shared_from_this());
+}
+
+void RDMABuffer::send_done_callback()
+{
+    std::unique_lock<std::mutex> lock(send_mutex_);
+    ++send_completed_;
+    send_cv_.notify_all();
+}
+
+void RDMABuffer::recv_done_callback()
+{
+    std::unique_lock<std::mutex> lock(recv_mutex_);
+    ++recv_completed_;
+    recv_cv_.notify_all();
 }
 
 bool RDMABuffer::waitSend()
@@ -35,10 +34,9 @@ bool RDMABuffer::waitSend()
     if (send_completed_)
         return send_completed_;
 
-    send_cv_.wait(lock, [this]() { return send_completed_; });
+    send_cv_.wait(lock, [this]() { return send_completed_ > 0; });
     send_pending_ = false;
     SLIME_LOG_INFO("complete to send the data.");
-
     return send_completed_;
 }
 
@@ -50,7 +48,7 @@ bool RDMABuffer::waitRecv()
         return recv_completed_;
 
     // waiting for the recv complete...
-    recv_cv_.wait(lock, [this]() { return recv_completed_; });
+    recv_cv_.wait(lock, [this]() { return recv_completed_ > 0; });
     recv_pending_ = false;
     SLIME_LOG_INFO("complete to recv the data.");
 

--- a/csrc/engine/rdma/rdma_buffer.h
+++ b/csrc/engine/rdma/rdma_buffer.h
@@ -13,51 +13,73 @@
 #include <unordered_map>
 #include <vector>
 
+#include "rdma_common.h"
+
 namespace slime {
 
 class RDMAEndpoint;
 
-class RDMABuffer : public std::enable_shared_from_this<RDMABuffer> {
+class RDMABuffer: public std::enable_shared_from_this<RDMABuffer> {
+    friend class RDMAEndpoint;
 
 public:
-    RDMABuffer(std::shared_ptr<RDMAEndpoint> end_point,
+    RDMABuffer(std::shared_ptr<RDMAEndpoint> endpoint, storage_view_batch_t& batch):
+        endpoint_(endpoint), storage_view_batch_(std::move(batch))
+    {
+    }
+
+    RDMABuffer(std::shared_ptr<RDMAEndpoint> endpoint,
                std::vector<uintptr_t>        ptrs,
                std::vector<size_t>           offset,
                std::vector<size_t>           data_size)
     {
         batch_size_ = ptrs.size();
         for (uint32_t i = 0; i < batch_size_; ++i) {
-            data_info.push_back(std::make_tuple(ptrs[i], data_size[i], offset[i]));
+            storage_view_t view{.data_ptr = ptrs[i], .storage_offset = offset[i], .length = data_size[i]};
+            storage_view_batch_.push_back(view);
         }
-        end_point_ = end_point;
+        endpoint_ = endpoint;
     }
 
     ~RDMABuffer() = default;
 
-    void send();
+    const size_t batchSize()
+    {
+        return storage_view_batch_.size();
+    }
 
+    const storage_view_batch_t& storageViewBatch()
+    {
+        return storage_view_batch_;
+    }
+
+    void send();
     void recv();
 
     bool waitSend();
-
     bool waitRecv();
 
+    void send_done_callback();
+    void recv_done_callback();
+
 private:
-    std::shared_ptr<RDMAEndpoint> end_point_;
+    std::shared_ptr<RDMAEndpoint> endpoint_;
 
     // <tensor_ptrs_, tensor_size_, offset>
     // tensor_ptrs: the pointer of the tensor
     // tensor_size: the length of the tensor
     // offset: the offset of the transmitted tensor
-    std::vector<std::tuple<uintptr_t, size_t, size_t>> data_info;
+    // std::vector<std::tuple<uintptr_t, size_t, size_t>> data_info;
+
+    storage_view_batch_t storage_view_batch_;
 
     size_t batch_size_;
 
-    bool send_pending_{false};
-    bool recv_pending_{false};
+    std::atomic<int> send_pending_{0};
+    std::atomic<int> recv_pending_{0};
 
-    bool send_completed_{false};
-    bool recv_completed_{false};
+    std::atomic<int> send_completed_{0};
+    std::atomic<int> recv_completed_{0};
 
     std::condition_variable send_cv_;
     std::condition_variable recv_cv_;

--- a/csrc/engine/rdma/rdma_common.h
+++ b/csrc/engine/rdma/rdma_common.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+namespace slime {
+
+typedef struct StorageView {
+    uintptr_t data_ptr;
+    size_t storage_offset;
+    size_t length;
+} storage_view_t;
+
+using storage_view_batch_t = std::vector<storage_view_t>;
+
+}

--- a/csrc/engine/rdma/rdma_context.h
+++ b/csrc/engine/rdma/rdma_context.h
@@ -83,6 +83,11 @@ public:
         SLIME_LOG_DEBUG("RDMAContext deconstructed")
     }
 
+    struct ibv_mr* get_mr(const std::string& mr_key)
+    {
+        return memory_pool_->get_mr(mr_key);
+    }
+
     /* Initialize */
     int64_t init(const std::string& dev_name, uint8_t ib_port, const std::string& link_type);
 
@@ -204,7 +209,7 @@ private:
     size_t            qp_list_len_{1};
     qp_management_t** qp_management_;
 
-    int last_qp_selection_ = -1;
+    int last_qp_selection_{-1};
     int select_qpi()
     {
         // Simplest round robin, we could enrich it in the future

--- a/csrc/engine/rdma/rdma_endpoint.cpp
+++ b/csrc/engine/rdma/rdma_endpoint.cpp
@@ -1,73 +1,182 @@
 #include "engine/rdma/rdma_endpoint.h"
+#include "engine/assignment.h"
+#include "engine/rdma/rdma_assignment.h"
+#include "engine/rdma/rdma_buffer.h"
+#include "engine/rdma/rdma_common.h"
+#include "engine/rdma/rdma_context.h"
+#include <atomic>
 #include <mutex>
+#include <string>
 
 namespace slime {
 
-void RDMAEndpoint::registerDataMemRegion(std::string str, uintptr_t ptr, size_t data_size)
+RDMATask::RDMATask(std::shared_ptr<RDMAEndpoint> endpoint,
+                   uint32_t                      task_id,
+                   OpCode                        opcode,
+                   std::shared_ptr<RDMABuffer>   buffer):
+    endpoint_(endpoint), slot_id_(task_id), opcode_(opcode), buffer_(buffer)
 {
-    data_ctx_->register_memory_region(str, ptr, data_size);
+    meta_data_buf_ = new meta_data_t[buffer->batchSize()];
+    registerMetaMemoryRegion();
+    registerDataMemoryRegion();
+    fillBuffer();
 }
 
-void RDMAEndpoint::registerMetaMemRegion(std::string str, uintptr_t ptr, size_t data_size)
+RDMATask::~RDMATask()
 {
-    meta_ctx_->register_memory_region(str, ptr, data_size);
+    delete[] meta_data_buf_;
 }
 
-void RDMAEndpoint::registerRemoteMemoryRegion(std::string mr_key, uintptr_t addr, size_t length, uint32_t rkey)
+std::string RDMATask::getMetaKey()
 {
-    json mr_info;
-    mr_info["addr"]   = addr;
-    mr_info["length"] = length;
-    mr_info["rkey"]   = rkey;
-    data_ctx_->register_remote_memory_region(mr_key, mr_info);
+    std::string meta_key = opcode_ == OpCode::SEND ? "META_SEND" : "META_RECV";
+    return meta_key + "@" + std::to_string(slot_id_);
 }
 
-void RDMAEndpoint::unregisterDataMemRegionBatch(std::string str, uint32_t batch_size)
+std::string RDMATask::getDataKey(int32_t idx)
 {
-    for (uint32_t i = 0; i < batch_size; ++i) {
-        std::string KEY = str + "_" + std::to_string(i);
-        data_ctx_->unregister_memory_region(KEY);
+    std::string data_key = opcode_ == OpCode::SEND ? "DATA_SEND" : "DATA_RECV";
+    return data_key + "@" + std::to_string(slot_id_) + "_" + std::to_string(idx);
+}
+
+AssignmentBatch RDMATask::getMetaAssignmentBatch()
+{
+    return AssignmentBatch{Assignment(getMetaKey(), 0, 0, sizeof(meta_data_t) * buffer_->batchSize())};
+}
+
+AssignmentBatch RDMATask::getDataAssignmentBatch()
+{
+    AssignmentBatch      batch;
+    storage_view_batch_t storage_view_batch = buffer_->storageViewBatch();
+    for (int i = 0; i < buffer_->batchSize(); ++i) {
+        batch.push_back(Assignment(getDataKey(i), 0, 0, storage_view_batch[i].length));
+    }
+    return batch;
+}
+
+int RDMATask::registerMetaMemoryRegion()
+{
+    endpoint_->MetaCtx()->register_memory_region(
+        getMetaKey(), (uintptr_t)meta_data_buf_, buffer_->batchSize() * sizeof(meta_data_t));
+    return 0;
+}
+
+int RDMATask::registerDataMemoryRegion()
+{
+    storage_view_batch_t storage_view_batch = buffer_->storageViewBatch();
+    for (int i = 0; i < buffer_->batchSize(); ++i) {
+        endpoint_->dataCtx()->register_memory_region(
+            getDataKey(i), storage_view_batch[i].data_ptr, storage_view_batch[i].length);
+    }
+    return 0;
+}
+
+void RDMATask::fillBuffer()
+{
+    for (size_t i = 0; i < buffer_->batchSize(); ++i) {
+        auto mr                    = endpoint_->dataCtx()->get_mr(getDataKey(i));
+        meta_data_buf_[i].mr_addr  = reinterpret_cast<uint64_t>(mr->addr);
+        meta_data_buf_[i].mr_rkey  = mr->rkey;
+        meta_data_buf_[i].mr_size  = mr->length;
+        meta_data_buf_[i].mr_slot  = slot_id_;
+        meta_data_buf_[i].mr_qpidx = slot_id_ % endpoint_->dataCtxQPNum();
     }
 }
 
-void RDMAEndpoint::unregisterMetaMemRegionBatch(std::string str, uint32_t batch_size)
+int RDMATask::targetQPI()
 {
-    for (uint32_t i = 0; i < batch_size; ++i) {
-        std::string KEY = str + "_" + std::to_string(i);
-        meta_ctx_->unregister_memory_region(KEY);
-    }
+    return meta_data_buf_[0].mr_qpidx;
 }
 
-void RDMAEndpoint::registerRecvMemRegionBatch(std::string str, std::vector<buffer_data_info_t> data_info)
+int RDMATask::registerRemoteDataMemoryRegion()
 {
-    // The mr key is followed by the form: str_ +"i"
-    for (size_t i = 0; i < data_info.size(); ++i) {
-        std::string KEY = str + "_" + std::to_string(i);
-        registerDataMemRegion(KEY, std::get<0>(data_info[i]), std::get<1>(data_info[i]));
+    for (size_t i = 0; i < buffer_->batchSize(); ++i) {
+        json     mr_info;
+        uint64_t addr     = meta_data_buf_[i].mr_addr;
+        uint32_t length   = meta_data_buf_[i].mr_size;
+        uint32_t rkey     = meta_data_buf_[i].mr_rkey;
+        mr_info["addr"]   = addr;
+        mr_info["length"] = length;
+        mr_info["rkey"]   = rkey;
+        endpoint_->dataCtx()->register_remote_memory_region(getDataKey(i), mr_info);
     }
+    return 0;
 }
 
-void RDMAEndpoint::registerSendMemRegionBatch(std::string str, std::vector<buffer_data_info_t> data_info)
+RDMAEndpoint::RDMAEndpoint(const std::string& dev_name, uint8_t ib_port, const std::string& link_type, size_t qp_num)
 {
-    // The mr key is followed by the form: str_ +"i"
-    for (uint32_t i = 0; i < data_info.size(); ++i) {
-        std::string KEY = str + "_" + std::to_string(i);
-        registerDataMemRegion(KEY, std::get<0>(data_info[i]), std::get<1>(data_info[i]));
+    SLIME_LOG_INFO("Init the Contexts and RDMA Devices...");
+    data_ctx_ = std::make_shared<RDMAContext>(qp_num);
+    meta_ctx_ = std::make_shared<RDMAContext>(1);
+
+    data_ctx_->init(dev_name, ib_port, link_type);
+    meta_ctx_->init(dev_name, ib_port, link_type);
+
+    data_ctx_qp_num_ = data_ctx_->qp_list_len_;
+    meta_ctx_qp_num_ = meta_ctx_->qp_list_len_;
+    SLIME_LOG_INFO("The QP number of data plane is: ", data_ctx_qp_num_);
+    SLIME_LOG_INFO("The QP number of control plane is: ", meta_ctx_qp_num_);
+    SLIME_LOG_INFO("RDMA Endpoint Init Success and Launch the RDMA Endpoint Task Threads...");
+}
+
+RDMAEndpoint::~RDMAEndpoint()
+{
+    {
+        std::unique_lock<std::mutex> lock(rdma_tasks_mutex_);
+        RDMA_tasks_threads_running_ = false;
     }
+
+    rdma_tasks_cv_.notify_all();
+
+    if (rdma_tasks_threads_.joinable())
+        rdma_tasks_threads_.join();
+}
+
+void RDMAEndpoint::connect(const json& data_ctx_info, const json& meta_ctx_info)
+{
+    data_ctx_->connect(data_ctx_info);
+    meta_ctx_->connect(meta_ctx_info);
+
+    data_ctx_->launch_future();
+    meta_ctx_->launch_future();
+
+    RDMA_tasks_threads_running_ = true;
+    rdma_tasks_threads_         = std::thread([this] { this->waitandPopTask(std::chrono::milliseconds(100)); });
+}
+
+std::shared_ptr<RDMABuffer> RDMAEndpoint::createRDMABuffer(storage_view_batch_t batch)
+{
+    std::unique_lock<std::mutex> lock(rdma_tasks_mutex_);
+    return std::make_shared<RDMABuffer>(shared_from_this(), batch);
+}
+
+void RDMAEndpoint::addSendTask(std::shared_ptr<RDMABuffer> buffer)
+{
+    std::unique_lock<std::mutex> lock(rdma_tasks_mutex_);
+    ++send_slot_id_;
+    auto task = std::make_shared<rdma_task_t>(shared_from_this(), send_slot_id_, OpCode::SEND, buffer);
+    send_batch_slot_[send_slot_id_] = task;
+    rdma_tasks_queue_.push(task);
+    rdma_tasks_cv_.notify_one();
+}
+
+void RDMAEndpoint::addRecvTask(std::shared_ptr<RDMABuffer> buffer)
+{
+    std::unique_lock<std::mutex> lock(rdma_tasks_mutex_);
+    ++recv_slot_id_;
+    auto task = std::make_shared<rdma_task_t>(shared_from_this(), recv_slot_id_, OpCode::RECV, buffer);
+    recv_batch_slot_[recv_slot_id_] = task;
+    rdma_tasks_queue_.push(task);
+    rdma_tasks_cv_.notify_one();
 }
 
 void RDMAEndpoint::waitandPopTask(std::chrono::milliseconds timeout)
 {
     while (true) {
-        RDMA_task_t task;
+        std::shared_ptr<rdma_task_t> task;
         {
             std::unique_lock<std::mutex> lock(rdma_tasks_mutex_);
-            bool timeout_occurred = !rdma_tasks_cv_.wait_for(lock, std::chrono::milliseconds(100), [this] {
-                return !rdma_tasks_queue_.empty() || !RDMA_tasks_threads_running_;
-            });
-
-            if (timeout_occurred)
-                continue;
+            rdma_tasks_cv_.wait(lock, [this] { return !rdma_tasks_queue_.empty() || !RDMA_tasks_threads_running_; });
 
             if (!RDMA_tasks_threads_running_ && rdma_tasks_queue_.empty())
                 break;
@@ -77,13 +186,12 @@ void RDMAEndpoint::waitandPopTask(std::chrono::milliseconds timeout)
                 rdma_tasks_queue_.pop();
             }
 
-            switch (task.op_code) {
+            switch (task->opcode_) {
                 case OpCode::SEND:
                     asyncSendData(task);
                     break;
                 case OpCode::RECV:
                     asyncRecvData(task);
-                    imm_data_callback_[task.task_id] = task.callback;
                     break;
                 default:
                     SLIME_LOG_ERROR("Unknown OpCode in WaitandPopTask");
@@ -93,128 +201,47 @@ void RDMAEndpoint::waitandPopTask(std::chrono::milliseconds timeout)
     }
 }
 
-uint32_t RDMAEndpoint::generateSendAssignmentBatch(std::vector<buffer_data_info_t> data_info)
+void RDMAEndpoint::asyncSendData(std::shared_ptr<rdma_task_t> task)
 {
-    send_slot_id_++;
-    std::string cur_key = "SEND_KEY_" + std::to_string(send_slot_id_);
-    registerSendMemRegionBatch(cur_key, data_info);
-    AssignmentBatch send_data_batch;
-    for (size_t i = 0; i < data_info.size(); ++i) {
-        std::string KEY = cur_key + "_" + std::to_string(i);
-        send_data_batch.push_back(Assignment(KEY, std::get<2>(data_info[i]), 0, std::get<1>(data_info[i])));
-    }
-    send_batch_slot_.emplace(send_slot_id_, send_data_batch);
-    return send_slot_id_;
-}
+    size_t   batch_size = task->buffer_->batchSize();
+    uint32_t slot_id    = task->slot_id_;
 
-uint32_t RDMAEndpoint::generateRecvAssignmentBatch(std::vector<buffer_data_info_t> data_info)
-{
-    recv_slot_id_++;
-    std::string cur_key = "RECV_KEY_" + std::to_string(recv_slot_id_);
-    registerRecvMemRegionBatch(cur_key, data_info);
-    AssignmentBatch recv_data_batch;
-    for (size_t i = 0; i < data_info.size(); ++i) {
-        std::string KEY = cur_key + "_" + std::to_string(i);
-        recv_data_batch.push_back(Assignment(KEY, std::get<2>(data_info[i]), 0, std::get<1>(data_info[i])));
-    }
-    recv_batch_slot_.emplace(recv_slot_id_, recv_data_batch);
-    return recv_slot_id_;
-}
-
-void RDMAEndpoint::asyncSendData(RDMA_task_t& task)
-{
-    size_t   batch_size    = task.batch_size;
-    uint32_t slot_id       = task.task_id;
-    auto     task_callback = task.callback;
-
-    std::string META_KEY = "SEND_META_" + std::to_string(slot_id);
-    std::string SEND_KEY = "SEND_DATA_" + std::to_string(slot_id);
-    auto meta_buf = std::shared_ptr<meta_data_t[]>(new meta_data_t[batch_size], std::default_delete<meta_data_t[]>());
-
-    auto data_callback = [this, SEND_KEY, META_KEY, batch_size, task_callback](int status, int _) mutable {
+    auto data_callback = [this, task](int status, int _) mutable {
         std::unique_lock<std::mutex> lock(rdma_tasks_mutex_);
-        task_callback();
+        this->send_batch_slot_[task->slot_id_]->buffer_->send_done_callback();
     };
 
-    auto meta_callback = [this, meta_buf, slot_id, batch_size, data_callback](int status, int _) mutable {
+    auto meta_callback = [this, task, data_callback](int status, int slot_id) mutable {
         std::unique_lock<std::mutex> lock(this->rdma_tasks_mutex_);
-        auto                         it = this->send_batch_slot_.find(slot_id);
-        if (it != this->send_batch_slot_.end()) {
-            auto send_data_batch = it->second;
-            for (size_t i = 0; i < batch_size; ++i) {
-                this->registerRemoteMemoryRegion(
-                    send_data_batch[i].mr_key, meta_buf[i].mr_addr, meta_buf[i].mr_size, meta_buf[i].mr_rkey);
-            }
-            uint32_t target_qpi = meta_buf[0].mr_qpidx;
-            auto     data_atx =
-                this->data_ctx_->submit(OpCode::WRITE_WITH_IMM, send_data_batch, data_callback, target_qpi, slot_id);
-        }
-        else {
-            std::cout << "The data in slot " << slot_id << " is not prepared" << std::endl;
-            std::cout << "There must be some bugs..." << std::endl;
-        }
+        task->registerRemoteDataMemoryRegion();
+        AssignmentBatch data_assign_batch = task->getDataAssignmentBatch();
+        auto            data_atx          = this->data_ctx_->submit(
+            OpCode::WRITE_WITH_IMM, data_assign_batch, data_callback, task->targetQPI(), slot_id);
     };
 
     {
-        std::unique_lock<std::mutex> lock(meta_data_mutex);
-        meta_ctx_->register_memory_region(
-            META_KEY, reinterpret_cast<uintptr_t>(meta_buf.get()), batch_size * sizeof(meta_data_t));
-
-        AssignmentBatch meta_data(1);
-        meta_data[0]  = Assignment(META_KEY, 0, 0, batch_size * sizeof(meta_data_t));
-        auto meta_atx = meta_ctx_->submit(OpCode::RECV, meta_data, meta_callback);
+        AssignmentBatch meta_data = task->getMetaAssignmentBatch();
+        meta_ctx_->submit(OpCode::RECV, meta_data, meta_callback);
     }
 }
 
-void RDMAEndpoint::asyncRecvData(RDMA_task_t& task)
+void RDMAEndpoint::asyncRecvData(std::shared_ptr<rdma_task_t> task)
 {
-
-    size_t   batch_size    = task.batch_size;
-    uint32_t slot_id       = task.task_id;
-    auto     task_callback = task.callback;
-
-    std::string META_KEY = "RECV_META_" + std::to_string(slot_id);
-    std::string RECV_KEY = "RECV_DATA_" + std::to_string(slot_id);
-    auto meta_buf = std::shared_ptr<meta_data_t[]>(new meta_data_t[batch_size], std::default_delete<meta_data_t[]>());
-
-    auto data_callback = [this, RECV_KEY, META_KEY, batch_size, task_callback](int status, int imm_data) mutable {
+    auto data_callback = [this, task](int status, int slot_id) mutable {
         std::unique_lock<std::mutex> lock(rdma_tasks_mutex_);
-        if (this->imm_data_callback_.find(imm_data) != this->imm_data_callback_.end()) {
-            this->imm_data_callback_[imm_data]();
-            this->imm_data_callback_.erase(imm_data);
-        }
+        recv_batch_slot_[slot_id]->buffer_->recv_done_callback();
     };
 
-    auto meta_callback = [this, meta_buf, slot_id, batch_size, data_callback](int status, int _) mutable {
-        std::unique_lock<std::mutex> lock(rdma_tasks_mutex_);
-        auto                         it = this->recv_batch_slot_.find(slot_id);
-        if (it != this->recv_batch_slot_.end()) {
-            auto     recv_data_batch = it->second;
-            uint32_t target_qpi      = meta_buf[0].mr_qpidx;
-            auto     data_atx = this->data_ctx_->submit(OpCode::RECV, recv_data_batch, data_callback, target_qpi);
-        }
+    auto meta_callback = [this, task, data_callback](int status, int _) mutable {
+        std::unique_lock<std::mutex> lock(this->rdma_tasks_mutex_);
+        AssignmentBatch              assign_batch = task->getDataAssignmentBatch();
+        auto data_atx = this->data_ctx_->submit(OpCode::RECV, assign_batch, data_callback, task->targetQPI());
     };
 
     {
-
-        std::unique_lock<std::mutex> lock(meta_data_mutex);
-        auto                         recv_data_t = recv_batch_slot_[slot_id];
-        for (size_t i = 0; i < batch_size; ++i) {
-            meta_buf[i].mr_addr =
-                reinterpret_cast<uint64_t>(data_ctx_->memory_pool_->get_mr(recv_data_t[i].mr_key)->addr);
-            meta_buf[i].mr_rkey  = data_ctx_->memory_pool_->get_mr(recv_data_t[i].mr_key)->rkey;
-            meta_buf[i].mr_size  = data_ctx_->memory_pool_->get_mr(recv_data_t[i].mr_key)->length;
-            meta_buf[i].mr_slot  = slot_id;
-            meta_buf[i].mr_qpidx = slot_id % data_ctx_qp_num_;
-        }
-
-        meta_ctx_->register_memory_region(
-            META_KEY, reinterpret_cast<uintptr_t>(meta_buf.get()), batch_size * sizeof(meta_data_t));
-
-        AssignmentBatch meta_data(1);
-        meta_data[0] = Assignment(META_KEY, 0, 0, batch_size * sizeof(meta_data_t));
-
-        auto meta_atx = meta_ctx_->submit(OpCode::SEND, meta_data, meta_callback);
+        auto            batch_size = task->buffer_->batchSize();
+        AssignmentBatch meta_data  = task->getMetaAssignmentBatch();
+        meta_ctx_->submit(OpCode::SEND_WITH_IMM, meta_data, meta_callback, RDMAContext::UNDEFINED_QPI, task->slot_id_);
     }
 }
 

--- a/csrc/engine/rdma/rdma_endpoint.h
+++ b/csrc/engine/rdma/rdma_endpoint.h
@@ -1,6 +1,8 @@
 #pragma once
+#include "engine/assignment.h"
 #include "engine/rdma/rdma_context.h"
 
+#include <atomic>
 #include <condition_variable>
 #include <infiniband/verbs.h>
 #include <map>
@@ -8,18 +10,21 @@
 #include <mutex>
 #include <queue>
 #include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <vector>
+
+#include "rdma_common.h"
 
 namespace slime {
 
 class RDMABuffer;
+class RDMAEndpoint;
 
-using buffer_data_info_t = std::tuple<uintptr_t, size_t, size_t>;
-using callback_t         = std::function<void()>;
-using json               = nlohmann::json;
+using callback_t = std::function<void()>;
+using json       = nlohmann::json;
 
-typedef struct meta_data {
+typedef struct MetaData {
 
     uint64_t mr_addr;
     uint32_t mr_rkey;
@@ -29,83 +34,50 @@ typedef struct meta_data {
 
 } __attribute__((packed)) meta_data_t;
 
-typedef struct RDMA_task {
+typedef struct RDMATask {
+    explicit RDMATask(std::shared_ptr<RDMAEndpoint> endpoint,
+                      uint32_t                      task_id,
+                      OpCode                        opcode,
+                      std::shared_ptr<RDMABuffer>   buffer);
+    ~RDMATask();
 
-    uint32_t   task_id;
-    uint32_t   batch_size;
-    OpCode     op_code;
-    callback_t callback;
+    std::string getMetaKey();
+    std::string getDataKey(int32_t idx);
 
+    AssignmentBatch getMetaAssignmentBatch();
+    AssignmentBatch getDataAssignmentBatch();
+
+    int registerMetaMemoryRegion();
+    int registerDataMemoryRegion();
+    int registerRemoteDataMemoryRegion();
+
+    void fillBuffer();
+
+    int targetQPI();
+
+    uint32_t                    slot_id_;
+    OpCode                      opcode_;
     std::shared_ptr<RDMABuffer> buffer_;
 
-} RDMA_task_t;
+    meta_data_t* meta_data_buf_{nullptr};
 
-class RDMAEndpoint {
+    std::shared_ptr<RDMAEndpoint> endpoint_;
+} rdma_task_t;
+
+class RDMAEndpoint: public std::enable_shared_from_this<RDMAEndpoint> {
+    friend class RDMABuffer;
 
 public:
-    RDMAEndpoint(const std::string& dev_name, uint8_t ib_port, const std::string& link_type, size_t qp_num)
-    {
-        SLIME_LOG_INFO("Init the Contexts and RDMA Devices...");
-        data_ctx_ = std::make_shared<RDMAContext>(qp_num);
-        meta_ctx_ = std::make_shared<RDMAContext>(1);
+    explicit RDMAEndpoint(const std::string& dev_name, uint8_t ib_port, const std::string& link_type, size_t qp_num);
 
-        data_ctx_->init(dev_name, ib_port, link_type);
-        meta_ctx_->init(dev_name, ib_port, link_type);
+    ~RDMAEndpoint();
 
-        data_ctx_qp_num_ = data_ctx_->qp_list_len_;
-        meta_ctx_qp_num_ = meta_ctx_->qp_list_len_;
-        SLIME_LOG_INFO("The QP number of data plane is: ", data_ctx_qp_num_);
-        SLIME_LOG_INFO("The QP number of control plane is: ", meta_ctx_qp_num_);
-        SLIME_LOG_INFO("RDMA Endpoint Init Success and Launch the RDMA Endpoint Task Threads...");
-        RDMA_tasks_threads_running_ = true;
-        rdma_tasks_threads_         = std::thread([this] { this->waitandPopTask(std::chrono::milliseconds(100)); });
-    }
+    void connect(const json& data_ctx_info, const json& meta_ctx_info);
 
-    ~RDMAEndpoint()
-    {
-        {
-            std::unique_lock<std::mutex> lock(rdma_tasks_mutex_);
-            RDMA_tasks_threads_running_ = false;
-        }
+    std::shared_ptr<RDMABuffer> createRDMABuffer(storage_view_batch_t batch);
 
-        rdma_tasks_cv_.notify_all();
-
-        if (rdma_tasks_threads_.joinable())
-            rdma_tasks_threads_.join();
-    }
-
-    void contextConnect(const json& data_ctx_info, const json& meta_ctx_info)
-    {
-        data_ctx_->connect(data_ctx_info);
-        meta_ctx_->connect(meta_ctx_info);
-
-        data_ctx_->launch_future();
-        meta_ctx_->launch_future();
-    }
-
-    void addRecvTask(std::vector<buffer_data_info_t> data_info, callback_t callback)
-    {
-        std::unique_lock<std::mutex> lock(rdma_tasks_mutex_);
-        RDMA_task_t                  task;
-        task.task_id    = generateRecvAssignmentBatch(data_info);
-        task.batch_size = data_info.size();
-        task.op_code    = OpCode::RECV;
-        task.callback   = callback;
-        rdma_tasks_queue_.push(std::move(task));
-        rdma_tasks_cv_.notify_one();
-    }
-
-    void addSendTask(std::vector<buffer_data_info_t> data_info, callback_t callback)
-    {
-        std::unique_lock<std::mutex> lock(rdma_tasks_mutex_);
-        RDMA_task_t                  task;
-        task.task_id    = generateSendAssignmentBatch(data_info);
-        task.batch_size = data_info.size();
-        task.op_code    = OpCode::SEND;
-        task.callback   = callback;
-        rdma_tasks_queue_.push(std::move(task));
-        rdma_tasks_cv_.notify_one();
-    }
+    void addRecvTask(std::shared_ptr<RDMABuffer> buffer);
+    void addSendTask(std::shared_ptr<RDMABuffer> buffer);
 
     json getDataContextInfo() const
     {
@@ -117,22 +89,26 @@ public:
         return meta_ctx_->endpoint_info();
     }
 
+    std::shared_ptr<RDMAContext> dataCtx()
+    {
+        return data_ctx_;
+    }
+
+    std::shared_ptr<RDMAContext> MetaCtx()
+    {
+        return meta_ctx_;
+    }
+
+    int dataCtxQPNum()
+    {
+        return data_ctx_qp_num_;
+    }
+
 private:
-    void     registerRecvMemRegionBatch(std::string str, std::vector<buffer_data_info_t> data_info);
-    void     registerSendMemRegionBatch(std::string str, std::vector<buffer_data_info_t> data_info);
-    uint32_t generateRecvAssignmentBatch(std::vector<buffer_data_info_t> data_info);
-    uint32_t generateSendAssignmentBatch(std::vector<buffer_data_info_t> data_info);
-
-    void registerRemoteMemoryRegion(std::string mr_key, uintptr_t addr, size_t length, uint32_t rkey);
-    void registerDataMemRegion(std::string str, uintptr_t ptr, size_t data_size);
-    void registerMetaMemRegion(std::string str, uintptr_t ptr, size_t data_size);
-    void unregisterDataMemRegionBatch(std::string str, uint32_t batch_size);
-    void unregisterMetaMemRegionBatch(std::string str, uint32_t batch_size);
-
     void waitandPopTask(std::chrono::milliseconds timeout);
 
-    void asyncRecvData(RDMA_task_t& task);
-    void asyncSendData(RDMA_task_t& task);
+    void asyncRecvData(std::shared_ptr<rdma_task_t> task);
+    void asyncSendData(std::shared_ptr<rdma_task_t> task);
 
     size_t data_ctx_qp_num_;
     size_t meta_ctx_qp_num_;
@@ -142,18 +118,17 @@ private:
 
     uint32_t batch_size_;
 
-    std::map<uint32_t, AssignmentBatch> send_batch_slot_;
-    std::map<uint32_t, AssignmentBatch> recv_batch_slot_;
+    std::map<uint32_t, std::shared_ptr<rdma_task_t>> send_batch_slot_;
+    std::map<uint32_t, std::shared_ptr<rdma_task_t>> recv_batch_slot_;
 
     std::shared_ptr<RDMAContext> data_ctx_;
     std::shared_ptr<RDMAContext> meta_ctx_;
 
-    std::queue<RDMA_task_t> rdma_tasks_queue_;
-    std::thread             rdma_tasks_threads_;
-    std::condition_variable rdma_tasks_cv_;
+    std::queue<std::shared_ptr<rdma_task_t>> rdma_tasks_queue_;
+    std::thread                              rdma_tasks_threads_;
 
-    std::mutex meta_data_mutex;
-    std::mutex rdma_tasks_mutex_;
+    std::condition_variable rdma_tasks_cv_;
+    std::mutex              rdma_tasks_mutex_;
 
     std::map<uint32_t, std::function<void()>> imm_data_callback_;
 

--- a/csrc/python/bind.cpp
+++ b/csrc/python/bind.cpp
@@ -78,7 +78,7 @@ PYBIND11_MODULE(_slime_c, m)
 
     py::class_<slime::RDMAEndpoint, std::shared_ptr<slime::RDMAEndpoint>>(m, "rdma_endpoint")
         .def(py::init<const std::string&, uint8_t, const std::string&, size_t>())
-        .def("context_connect", &slime::RDMAEndpoint::contextConnect)
+        .def("context_connect", &slime::RDMAEndpoint::connect)
         .def("get_data_context_info", &slime::RDMAEndpoint::getDataContextInfo)
         .def("get_meta_context_info", &slime::RDMAEndpoint::getMetaContextInfo);
 

--- a/csrc/torch/slime_backend.h
+++ b/csrc/torch/slime_backend.h
@@ -22,7 +22,7 @@ class TORCH_API SendWork: public ::c10d::Work {
     friend class slimeBackend;
 
 public:
-    explicit SendWork(std::vector<at::Tensor>& tensor, std::unique_ptr<::slime::RDMABuffer> buffer, uint64_t seq);
+    explicit SendWork(std::vector<at::Tensor>& tensor, std::shared_ptr<::slime::RDMABuffer> buffer, uint64_t seq);
     bool wait(std::chrono::milliseconds timeout = kNoTimeout) override;
     void abort() override
     {
@@ -31,7 +31,7 @@ public:
 
 protected:
     std::vector<at::Tensor>              tensor_;
-    std::unique_ptr<::slime::RDMABuffer> buffer_;
+    std::shared_ptr<::slime::RDMABuffer> buffer_;
     int                                  dstRank_;
     const uint64_t                       seq_;
 };
@@ -40,7 +40,7 @@ class TORCH_API RecvWork: public ::c10d::Work {
     friend class slimeBackend;
 
 public:
-    explicit RecvWork(std::vector<at::Tensor>& tensor, std::unique_ptr<::slime::RDMABuffer> buffer, uint64_t seq);
+    explicit RecvWork(std::vector<at::Tensor>& tensor, std::shared_ptr<::slime::RDMABuffer> buffer, uint64_t seq);
     bool wait(std::chrono::milliseconds timeout = kNoTimeout) override;
     void abort() override
     {
@@ -49,7 +49,7 @@ public:
 
 protected:
     std::vector<at::Tensor>              tensor_;
-    std::unique_ptr<::slime::RDMABuffer> buffer_;
+    std::shared_ptr<::slime::RDMABuffer> buffer_;
     int                                  srcRank_;
     const uint64_t                       seq_;
 };


### PR DESCRIPTION
``` shell
SLIME_QP_NUM=1 MASTER_ADDR=127.0.0.1 MASTER_PORT=7000 RANK=1 WORLD_SIZE=2 python bench/python/sendrecv_bench.py --num-concurrency 8
SLIME_QP_NUM=1 MASTER_ADDR=127.0.0.1 MASTER_PORT=7000 RANK=0 WORLD_SIZE=2 python bench/python/sendrecv_bench.py --num-concurrency 8
```
``` python
Benchmark Results:
+------------------------+---------------------------+---------------+---------------+
|   Message Size (bytes) |   Total Transport (bytes) | Avg Latency   | Bandwidth     |
+========================+===========================+===============+===============+
|                   2048 |                     16384 | 267.47 ms     | 0.77 MB/s     |
+------------------------+---------------------------+---------------+---------------+
|                   4096 |                     32768 | 244.23 ms     | 1.68 MB/s     |
+------------------------+---------------------------+---------------+---------------+
|                   8192 |                     65536 | 238.73 ms     | 3.43 MB/s     |
+------------------------+---------------------------+---------------+---------------+
|                  16384 |                    131072 | 218.42 ms     | 7.50 MB/s     |
+------------------------+---------------------------+---------------+---------------+
|                  32768 |                    262144 | 215.98 ms     | 15.17 MB/s    |
+------------------------+---------------------------+---------------+---------------+
|                  65536 |                    524288 | 224.38 ms     | 29.21 MB/s    |
+------------------------+---------------------------+---------------+---------------+
|                 131072 |                   1048576 | 223.36 ms     | 58.68 MB/s    |
+------------------------+---------------------------+---------------+---------------+
|                 262144 |                   2097152 | 228.55 ms     | 114.70 MB/s   |
+------------------------+---------------------------+---------------+---------------+
|                 524288 |                   4194304 | 232.80 ms     | 225.21 MB/s   |
+------------------------+---------------------------+---------------+---------------+
|                1048576 |                   8388608 | 221.25 ms     | 473.94 MB/s   |
+------------------------+---------------------------+---------------+---------------+
|                2097152 |                  16777216 | 247.58 ms     | 847.07 MB/s   |
+------------------------+---------------------------+---------------+---------------+
|                4194304 |                  33554432 | 248.27 ms     | 1689.42 MB/s  |
+------------------------+---------------------------+---------------+---------------+
|                8388608 |                  67108864 | 233.03 ms     | 3599.86 MB/s  |
+------------------------+---------------------------+---------------+---------------+
|               16777216 |                 134217728 | 260.41 ms     | 6442.51 MB/s  |
+------------------------+---------------------------+---------------+---------------+
|               33554432 |                 268435456 | 339.35 ms     | 9887.88 MB/s  |
+------------------------+---------------------------+---------------+---------------+
|               67108864 |                 536870912 | 441.75 ms     | 15191.47 MB/s |
+------------------------+---------------------------+---------------+---------------+
|              134217728 |                1073741824 | 693.08 ms     | 19365.40 MB/s |
+------------------------+---------------------------+---------------+---------------+
```