### PR TITLE
1. add write-with-imm-data example

### DIFF
--- a/csrc/python/bind.cpp
+++ b/csrc/python/bind.cpp
@@ -44,6 +44,7 @@ PYBIND11_MODULE(_slime_c, m)
     py::enum_<slime::OpCode>(m, "OpCode")
         .value("READ", slime::OpCode::READ)
         .value("WRITE", slime::OpCode::WRITE)
+        .value("WRITE_WITH_IMM_DATA", slime::OpCode::WRITE_WITH_IMM)
         .value("SEND", slime::OpCode::SEND)
         .value("RECV", slime::OpCode::RECV);
 
@@ -64,8 +65,9 @@ PYBIND11_MODULE(_slime_c, m)
         .def("submit_assignment", &slime::RDMAScheduler::submitAssignment)
         .def("scheduler_info", &slime::RDMAScheduler::scheduler_info);
 
-    py::class_<slime::RDMAContext>(m, "rdma_context")
+    py::class_<slime::RDMAContext, std::shared_ptr<slime::RDMAContext>>(m, "rdma_context")
         .def(py::init<>())
+        .def(py::init<size_t>())
         .def("init_rdma_context", &slime::RDMAContext::init)
         .def("register_memory_region", &slime::RDMAContext::register_memory_region)
         .def("register_remote_memory_region",

--- a/dlslime/remote_io/rdma_endpoint.py
+++ b/dlslime/remote_io/rdma_endpoint.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Dict, List
+import os
+from typing import Any, Callable, Dict, List, Optional
 
 from dlslime import _slime_c
 from dlslime.assignment import Assignment
@@ -22,6 +23,7 @@ class RDMAEndpoint(BaseEndpoint):
         device_name: str,
         ib_port: int = 1,
         link_type: str = 'RoCE',
+        qp_num: Optional[int] = None,
     ):
         """Initialize an RDMA endpoint bound to specific hardware resources.
 
@@ -30,7 +32,9 @@ class RDMAEndpoint(BaseEndpoint):
             ib_port: InfiniBand physical port number (1-based indexing)
             transport_type: Underlying transport ('RoCE' or 'InfiniBand')
         """
-        self._ctx: _slime_c.rdma_context = _slime_c.rdma_context()
+        if not qp_num:
+            qp_num = int(os.getenv('QP_NUM', 1))
+        self._ctx: _slime_c.rdma_context = _slime_c.rdma_context(qp_num)
         self.initialize(device_name, ib_port, link_type)
         self.assignment_with_callback = {}
 
@@ -126,8 +130,30 @@ class RDMAEndpoint(BaseEndpoint):
     def recv_batch(
         self,
         batch: List[Assignment],
+        qpi: int = -1,
         async_op=False,
     ) -> _slime_c.RDMAAssignment:
+        """
+        Perform batched receive of SEND, SEND_WITH_IMM_DATA
+            and WRITE_WITH_IMM_DATA operations.
+
+        Args:
+            batch: List of Assignment objects containing:
+                - mr_key: Remote MR identifier
+                - target_offset: Offset in remote MR (bytes)
+                - source_offset: Local source VA offset (bytes)
+                - length: Data size in bytes
+            qpi: Queue Pair Index for the operation
+            async_op: If True, returns RDMAAssignment for asynchronous handling
+
+        Returns:
+            (AsyncOp=False) int: ibv_wc_status code (0 = IBV_WC_SUCCESS)
+            (AsyncOp=True) RDMAAssignment object for tracking the operation status.
+
+        Warning:
+            1. This method is not thread-safe and should not be called concurrently.
+            2. The caller must ensure that the QP index (qpi) is valid and matches the remote endpoint's QP.
+        """
         rdma_assignment = self._ctx.submit(_slime_c.OpCode.RECV, [
             _slime_c.Assignment(
                 assign.mr_key,
@@ -135,7 +161,7 @@ class RDMAEndpoint(BaseEndpoint):
                 assign.source_offset,
                 assign.length,
             ) for assign in batch
-        ], None, -1, -1)
+        ], None, qpi, -1)
         if not async_op:
             return rdma_assignment.wait()
         else:
@@ -173,7 +199,11 @@ class RDMAEndpoint(BaseEndpoint):
             read_size: Data size in bytes
 
         Returns:
-            ibv_wc_status code (0 = IBV_WC_SUCCESS)
+            (AsyncOp=False) ibv_wc_status code (0 = IBV_WC_SUCCESS)
+            (AsyncOp=True) RDMAAssignment object for tracking the operation status.
+
+        Warning:
+            This method is not thread-safe and should not be called concurrently.
         """
         rdma_assignment = self._ctx.submit(_slime_c.OpCode.READ, [
             _slime_c.Assignment(
@@ -183,6 +213,46 @@ class RDMAEndpoint(BaseEndpoint):
                 assign.length,
             ) for assign in batch
         ], None, -1, -1)
+        if async_op:
+            return rdma_assignment
+        else:
+            return rdma_assignment.wait()
+
+    def write_batch_with_imm_data(
+        self,
+        batch: List[Assignment],
+        qpi: int = -1,
+        imm_data: int = -1,
+        async_op=False,
+    ) -> _slime_c.RDMAAssignment:
+        """Perform batched write with immediate data to remote MR.
+
+        Args:
+            batch: List of Assignment objects containing:
+                - mr_key: Remote MR identifier
+                - target_offset: Offset in remote MR (bytes)
+                - source_offset: Local source VA offset (bytes)
+                - length: Data size in bytes
+            qpi: Queue Pair Index for the operation
+            imm_data: Immediate data to be sent with the write operation
+
+        Returns:
+            RDMAAssignment object for tracking the operation status.
+        """
+        rdma_assignment = self._ctx.submit(
+            _slime_c.OpCode.WRITE_WITH_IMM_DATA,
+            [  # type: ignore
+                _slime_c.Assignment(
+                    assign.mr_key,
+                    assign.target_offset,
+                    assign.source_offset,
+                    assign.length,
+                ) for assign in batch
+            ],
+            None,
+            qpi,
+            imm_data,
+        )
         if async_op:
             return rdma_assignment
         else:

--- a/example/python/p2p_rdma_rc_write_with_imm_data.py
+++ b/example/python/p2p_rdma_rc_write_with_imm_data.py
@@ -1,0 +1,57 @@
+import torch
+
+from dlslime import Assignment, RDMAEndpoint, available_nic
+
+devices = available_nic()
+assert devices, 'No RDMA devices.'
+
+# Initialize RDMA endpoint
+initiator = RDMAEndpoint(device_name=devices[0], ib_port=1, link_type='RoCE')
+target = RDMAEndpoint(device_name=devices[-1], ib_port=1, link_type='RoCE')
+
+# Register local GPU memory with RDMA subsystem
+local_tensor = torch.zeros([16], device='cuda:0', dtype=torch.uint8)
+initiator.register_memory_region(
+    mr_key='buffer',
+    addr=local_tensor.data_ptr(),
+    offset=local_tensor.storage_offset(),
+    length=local_tensor.numel() * local_tensor.itemsize,
+)
+remote_tensor = torch.ones([16], device='cuda', dtype=torch.uint8)
+target.register_memory_region(
+    mr_key='buffer',
+    addr=remote_tensor.data_ptr(),
+    offset=remote_tensor.storage_offset(),
+    length=remote_tensor.numel() * remote_tensor.itemsize,
+)
+
+# Establish bidirectional RDMA connection:
+# 1. Target connects to initiator's endpoint information
+# 2. Initiator connects to target's endpoint information
+# Note: Real-world scenarios typically use out-of-band exchange (e.g., via TCP)
+target.connect(initiator.endpoint_info)
+initiator.connect(target.endpoint_info)
+
+print('Remote tensor after RDMA write:', remote_tensor)
+future_write = initiator.write_batch_with_imm_data(
+    [Assignment(mr_key='buffer', target_offset=0, source_offset=8, length=8)],
+    qpi=0,
+    imm_data=1,
+    async_op=True,
+)
+
+future_recv = target.recv_batch(
+    [Assignment(mr_key='buffer', target_offset=0, source_offset=0, length=8)],
+    qpi=0,
+    async_op=True,
+)
+
+future_write.wait()
+future_recv.wait()
+
+assert torch.all(remote_tensor[:8] == 0)
+assert torch.all(remote_tensor[8:] == 1)
+print('Remote tensor after RDMA write:', remote_tensor)
+
+del target, initiator
+print('run rdma rc write example successful')


### PR DESCRIPTION
```
$ SLIME_QP_NUM=2 python bench/python/transfer_bench.py --rank 1 --num-concurrency 2 --with-imm-data --opcode write
$ SLIME_QP_NUM=2 python bench/python/transfer_bench.py --rank 0 --num-concurrency 2 --with-imm-data --opcode write
mode: RDMA RC write
num concurrency: 2
Benchmark Results:
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| Message Size (bytes)   | Total Transport (bytes)   |   Target Affinity |   Initiator Affinity |   Avg Latency(ms) |   Bandwidth(MB/s) |
+========================+===========================+===================+======================+===================+===================+
| 2,048                  | 4,096                     |                 0 |                    1 |              0.02 |             97.96 |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 4,096                  | 8,192                     |                 0 |                    1 |              0.02 |            209.37 |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 8,192                  | 16,384                    |                 0 |                    1 |              0.02 |            418.45 |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 16,384                 | 32,768                    |                 0 |                    1 |              0.03 |            783.73 |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 32,768                 | 65,536                    |                 0 |                    1 |              0.03 |           1626.55 |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 65,536                 | 131,072                   |                 0 |                    1 |              0.03 |           3055.99 |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 131,072                | 262,144                   |                 0 |                    1 |              0.03 |           5728.51 |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 262,144                | 524,288                   |                 0 |                    1 |              0.03 |          10351.1  |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 524,288                | 1,048,576                 |                 0 |                    1 |              0.05 |          17432.7  |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 1,048,576              | 2,097,152                 |                 0 |                    1 |              0.07 |          25730.9  |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 2,097,152              | 4,194,304                 |                 0 |                    1 |              0.11 |          33739.6  |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 4,194,304              | 8,388,608                 |                 0 |                    1 |              0.2  |          39797.6  |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 8,388,608              | 16,777,216                |                 0 |                    1 |              0.37 |          43479.8  |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 16,777,216             | 33,554,432                |                 0 |                    1 |              0.71 |          45812.1  |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 33,554,432             | 67,108,864                |                 0 |                    1 |              1.39 |          47264.3  |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 67,108,864             | 134,217,728               |                 0 |                    1 |              2.77 |          48131.8  |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
| 134,217,728            | 268,435,456               |                 0 |                    1 |              5.51 |          48454.6  |
+------------------------+---------------------------+-------------------+----------------------+-------------------+-------------------+
```