### PR TITLE
Fix RDMA imm recv RNR handling

### DIFF
--- a/dlslime/__init__.py
+++ b/dlslime/__init__.py
@@ -1,6 +1,8 @@
 from ._slime_c import *
 import os
 
+from .logging import get_logger, set_log_level
+
 try:
     from .peer_agent import PeerAgent, start_peer_agent
 except ImportError as e:

--- a/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
+++ b/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
@@ -450,6 +450,9 @@ void RDMAEndpoint::postImmRecvSlot(ImmRecvContext* ctx)
 
 void RDMAEndpoint::postImmRecvWindow()
 {
+    // Fill the IO receive queues independently of user immRecv() calls. This
+    // is the RNR-avoidance window: WRITE_WITH_IMM should find a posted receive
+    // even if the application has not yet asked for the next message.
     for (int i = 0; i < SLIME_MAX_IO_FIFO_DEPTH; ++i) {
         ImmRecvContext* ctx = &imm_recv_ctx_pool_[i];
         ctx->slot_id        = i;
@@ -473,6 +476,9 @@ void RDMAEndpoint::completeImmRecvOp(const std::shared_ptr<ImmRecvOpState>& op_s
 
 void RDMAEndpoint::enqueueImmRecvCompletion(ImmRecvContext* ctx)
 {
+    // CQ callbacks run on the polling thread. Copy the reusable transport
+    // slot's result into a small event, match it to a user op if possible, and
+    // let the endpoint progress loop repost the slot outside the callback.
     ImmRecvEvent event{
         ctx->completion_status.load(std::memory_order_acquire),
         ctx->imm_data.load(std::memory_order_acquire),
@@ -704,6 +710,9 @@ std::shared_ptr<ImmRecvFuture> RDMAEndpoint::immRecv(void* stream)
 {
     io_recv_slot_id_.fetch_add(1, std::memory_order_relaxed);
 
+    // One user-level receive operation. It may complete immediately from a
+    // queued event, or wait in pending_imm_recv_ops_ until a future CQ event
+    // arrives. It does not own a hardware receive slot.
     auto op_state               = std::make_shared<ImmRecvOpState>();
     op_state->signal            = dlslime::device::createSignal(false);
     op_state->expected_mask     = (1u << num_qp_) - 1;
@@ -782,6 +791,8 @@ int32_t RDMAEndpoint::immRecvProcess()
 {
     int32_t work_done = 0;
 
+    // Repost completed transport slots. Keeping refill out of the CQ callback
+    // avoids mutating RDMAAssign while its callback is still executing.
     while (true) {
         ImmRecvContext* ctx = nullptr;
         {

--- a/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
+++ b/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <memory>
 #include <new>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -123,7 +124,6 @@ void RDMAEndpoint::init(std::shared_ptr<RDMAWorker> worker)
 
     for (size_t i = 0; i < SLIME_MAX_IO_FIFO_DEPTH; ++i) {
         read_write_future_pool_.push_back(std::make_shared<ReadWriteFuture>(&(read_write_ctx_pool_[i])));
-        imm_recv_future_pool_.push_back(std::make_shared<ImmRecvFuture>(&(imm_recv_ctx_pool_[i])));
     }
 
     void* io_dummy_mem = nullptr;
@@ -271,6 +271,7 @@ void RDMAEndpoint::connect(const json& remote_endpoint_info)
     // Connect IO Endpoint
     if (remote_endpoint_info.contains("io_info")) {
         io_data_channel_->connect(remote_endpoint_info["io_info"]["data_channel_info"]);
+        postImmRecvWindow();
     }
     else {
         SLIME_LOG_WARN("UnifiedConnect: Missing 'io_info' in remote info");
@@ -409,19 +410,89 @@ void RDMAEndpoint::dummyReset(ImmRecvContext* ctx)
         ctx->assigns_[qpi].batch_[0].target_offset = 0;
         ctx->assigns_[qpi].batch_[0].source_offset = 0;
 
-        ctx->assigns_[qpi].callback_ = [ctx, qpi](int32_t status, int32_t imm) {
+        ctx->assigns_[qpi].callback_ = [this, ctx, qpi](int32_t status, int32_t imm) {
             if (status != RDMAAssign::SUCCESS) {
                 int32_t expected = RDMAAssign::SUCCESS;
                 ctx->completion_status.compare_exchange_strong(
                     expected, status, std::memory_order_release, std::memory_order_relaxed);
             }
-            ctx->assigns_[qpi].imm_data_ = (status == RDMAAssign::SUCCESS) ? imm : 0;
-            ctx->signal->set_comm_done(qpi);
+            else if (qpi == 0) {
+                ctx->imm_data.store(imm, std::memory_order_release);
+            }
+
+            uint32_t old_mask = ctx->finished_qp_mask.fetch_or(1u << qpi, std::memory_order_acq_rel);
+            uint32_t new_mask = old_mask | (1u << qpi);
+            if (new_mask == ctx->expected_mask) {
+                enqueueImmRecvCompletion(ctx);
+            }
         };
 
         ctx->assigns_[qpi].is_inline_ = false;
 
         ctx->assigns_[qpi].imm_data_ = 0;
+    }
+}
+
+void RDMAEndpoint::postImmRecvSlot(ImmRecvContext* ctx)
+{
+    ctx->expected_mask = (1u << num_qp_) - 1;
+    ctx->finished_qp_mask.store(0, std::memory_order_release);
+    ctx->completion_status.store(RDMAAssign::SUCCESS, std::memory_order_release);
+    ctx->imm_data.store(0, std::memory_order_release);
+
+    dummyReset(ctx);
+
+    for (size_t qpi = 0; qpi < num_qp_; ++qpi) {
+        io_data_channel_->post_recv_batch(qpi, &(ctx->assigns_[qpi]), meta_pool_);
+    }
+    ctx->state_ = IOContextState::POSTED;
+}
+
+void RDMAEndpoint::postImmRecvWindow()
+{
+    for (int i = 0; i < SLIME_MAX_IO_FIFO_DEPTH; ++i) {
+        ImmRecvContext* ctx = &imm_recv_ctx_pool_[i];
+        ctx->slot_id        = i;
+        postImmRecvSlot(ctx);
+    }
+}
+
+void RDMAEndpoint::completeImmRecvOp(const std::shared_ptr<ImmRecvOpState>& op_state, const ImmRecvEvent& event)
+{
+    if (!op_state) {
+        return;
+    }
+    op_state->completion_status.store(event.status, std::memory_order_release);
+    op_state->imm_data.store(event.imm_data, std::memory_order_release);
+    if (op_state->signal) {
+        for (size_t qpi = 0; qpi < num_qp_; ++qpi) {
+            op_state->signal->set_comm_done(qpi);
+        }
+    }
+}
+
+void RDMAEndpoint::enqueueImmRecvCompletion(ImmRecvContext* ctx)
+{
+    ImmRecvEvent event{
+        ctx->completion_status.load(std::memory_order_acquire),
+        ctx->imm_data.load(std::memory_order_acquire),
+    };
+
+    std::shared_ptr<ImmRecvOpState> op_state;
+    {
+        std::lock_guard<std::mutex> guard(imm_recv_mutex_);
+        if (!pending_imm_recv_ops_.empty()) {
+            op_state = std::move(pending_imm_recv_ops_.front());
+            pending_imm_recv_ops_.pop_front();
+        }
+        else if (event.status == RDMAAssign::SUCCESS) {
+            completed_imm_recv_events_.push_back(event);
+        }
+        pending_imm_recv_refill_.push_back(ctx);
+    }
+
+    if (op_state) {
+        completeImmRecvOp(op_state, event);
     }
 }
 
@@ -631,12 +702,33 @@ RDMAEndpoint::writeWithImm(const std::vector<assign_tuple_t>& assign, int32_t im
 
 std::shared_ptr<ImmRecvFuture> RDMAEndpoint::immRecv(void* stream)
 {
-    uint64_t        slot = io_recv_slot_id_.fetch_add(1, std::memory_order_relaxed) % SLIME_MAX_IO_FIFO_DEPTH;
-    ImmRecvContext* ctx  = &imm_recv_ctx_pool_[slot];
+    io_recv_slot_id_.fetch_add(1, std::memory_order_relaxed);
 
-    ctx->signal->bind_stream(stream);
+    auto op_state               = std::make_shared<ImmRecvOpState>();
+    op_state->signal            = dlslime::device::createSignal(false);
+    op_state->expected_mask     = (1u << num_qp_) - 1;
+    op_state->completion_status = RDMAAssign::SUCCESS;
+    op_state->imm_data          = 0;
+    op_state->signal->reset_all();
+    op_state->signal->bind_stream(stream);
 
-    return imm_recv_future_pool_[slot];
+    std::optional<ImmRecvEvent> ready_event;
+    {
+        std::lock_guard<std::mutex> guard(imm_recv_mutex_);
+        if (!completed_imm_recv_events_.empty()) {
+            ready_event = completed_imm_recv_events_.front();
+            completed_imm_recv_events_.pop_front();
+        }
+        else {
+            pending_imm_recv_ops_.push_back(op_state);
+        }
+    }
+
+    if (ready_event) {
+        completeImmRecvOp(op_state, *ready_event);
+    }
+
+    return std::make_shared<ImmRecvFuture>(op_state);
 }
 
 // ============================================================
@@ -690,41 +782,18 @@ int32_t RDMAEndpoint::immRecvProcess()
 {
     int32_t work_done = 0;
 
-    const uint64_t PRE_POST_WINDOW = 32;
-
-    uint64_t user_req_cnt = io_recv_slot_id_.load(std::memory_order_relaxed);
-    uint64_t posted_cnt   = posted_recv_cnt_.load(std::memory_order_relaxed);
-
-    uint64_t target_post = user_req_cnt + PRE_POST_WINDOW;
-
-    while (posted_cnt < target_post) {
-        uint64_t slot = posted_cnt % SLIME_MAX_IO_FIFO_DEPTH;
-
-        if (posted_cnt > user_req_cnt + SLIME_MAX_IO_FIFO_DEPTH) {
-            break;
+    while (true) {
+        ImmRecvContext* ctx = nullptr;
+        {
+            std::lock_guard<std::mutex> guard(imm_recv_mutex_);
+            if (pending_imm_recv_refill_.empty()) {
+                break;
+            }
+            ctx = pending_imm_recv_refill_.front();
+            pending_imm_recv_refill_.pop_front();
         }
-
-        ImmRecvContext* ctx = &imm_recv_ctx_pool_[slot];
-
-        ctx->slot_id       = slot;
-        ctx->expected_mask = (1 << num_qp_) - 1;
-        ctx->completion_status.store(RDMAAssign::SUCCESS, std::memory_order_release);
-
-        ctx->signal->reset_all();
-
-        dummyReset(ctx);
-
-        for (size_t qpi = 0; qpi < num_qp_; ++qpi) {
-            io_data_channel_->post_recv_batch(qpi, &(ctx->assigns_[qpi]), meta_pool_);
-        }
-        ctx->state_ = IOContextState::POSTED;
-
-        posted_cnt++;
+        postImmRecvSlot(ctx);
         work_done++;
-    }
-
-    if (work_done > 0) {
-        posted_recv_cnt_.store(posted_cnt, std::memory_order_relaxed);
     }
 
     return work_done;
@@ -928,6 +997,21 @@ int32_t RDMAEndpoint::process()
 
 void RDMAEndpoint::cancelAll()
 {
+    {
+        std::lock_guard<std::mutex> guard(imm_recv_mutex_);
+        for (auto& op_state : pending_imm_recv_ops_) {
+            if (op_state) {
+                op_state->completion_status.store(RDMAAssign::FAILED, std::memory_order_release);
+                if (op_state->signal) {
+                    op_state->signal->force_complete();
+                }
+            }
+        }
+        pending_imm_recv_ops_.clear();
+        completed_imm_recv_events_.clear();
+        pending_imm_recv_refill_.clear();
+    }
+
     for (int i = 0; i < SLIME_MAX_IO_FIFO_DEPTH; ++i) {
         if (read_write_ctx_pool_) {
             read_write_ctx_pool_[i].signal->force_complete();

--- a/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
+++ b/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -34,6 +35,17 @@
 #include "rdma_worker_pool.h"
 
 namespace dlslime {
+
+namespace {
+
+uint64_t monotonic_time_ns()
+{
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
+            .count());
+}
+
+}  // namespace
 
 // ============================================================
 // Constructor & Setup
@@ -467,6 +479,9 @@ void RDMAEndpoint::completeImmRecvOp(const std::shared_ptr<ImmRecvOpState>& op_s
     }
     op_state->completion_status.store(event.status, std::memory_order_release);
     op_state->imm_data.store(event.imm_data, std::memory_order_release);
+    if (SLIME_WITH_TIME_TRACE) {
+        op_state->trace_end_ns.store(event.trace_end_ns, std::memory_order_release);
+    }
     if (op_state->signal) {
         for (size_t qpi = 0; qpi < num_qp_; ++qpi) {
             op_state->signal->set_comm_done(qpi);
@@ -482,6 +497,7 @@ void RDMAEndpoint::enqueueImmRecvCompletion(ImmRecvContext* ctx)
     ImmRecvEvent event{
         ctx->completion_status.load(std::memory_order_acquire),
         ctx->imm_data.load(std::memory_order_acquire),
+        SLIME_WITH_TIME_TRACE ? monotonic_time_ns() : 0,
     };
 
     std::shared_ptr<ImmRecvOpState> op_state;
@@ -718,6 +734,10 @@ std::shared_ptr<ImmRecvFuture> RDMAEndpoint::immRecv(void* stream)
     op_state->expected_mask     = (1u << num_qp_) - 1;
     op_state->completion_status = RDMAAssign::SUCCESS;
     op_state->imm_data          = 0;
+    if (SLIME_WITH_TIME_TRACE) {
+        op_state->trace_start_ns.store(monotonic_time_ns(), std::memory_order_release);
+        op_state->trace_end_ns.store(0, std::memory_order_release);
+    }
     op_state->signal->reset_all();
     op_state->signal->bind_stream(stream);
 

--- a/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
+++ b/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
@@ -460,6 +460,23 @@ void RDMAEndpoint::postImmRecvWindow()
     }
 }
 
+void RDMAEndpoint::pushRefill(ImmRecvContext* ctx)
+{
+    // Lock-free MPSC push: CQ callback threads push completed slots.
+    ImmRecvContext* old_head = refill_head_.load(std::memory_order_relaxed);
+    do {
+        ctx->next_refill_.store(old_head, std::memory_order_relaxed);
+    } while (!refill_head_.compare_exchange_weak(
+        old_head, ctx, std::memory_order_release, std::memory_order_relaxed));
+}
+
+ImmRecvContext* RDMAEndpoint::popAllRefill()
+{
+    // Atomically grab the entire refill chain. Only the progress thread calls
+    // this, so a single exchange is sufficient (no ABA concern).
+    return refill_head_.exchange(nullptr, std::memory_order_acquire);
+}
+
 void RDMAEndpoint::completeImmRecvOp(const std::shared_ptr<ImmRecvOpState>& op_state, const ImmRecvEvent& event)
 {
     if (!op_state) {
@@ -490,7 +507,7 @@ void RDMAEndpoint::enqueueImmRecvCompletion(ImmRecvContext* ctx)
 
     std::shared_ptr<ImmRecvOpState> op_state;
     {
-        std::lock_guard<std::mutex> guard(imm_recv_mutex_);
+        std::lock_guard<SpinLock> guard(imm_recv_match_lock_);
         if (!pending_imm_recv_ops_.empty()) {
             op_state = std::move(pending_imm_recv_ops_.front());
             pending_imm_recv_ops_.pop_front();
@@ -501,8 +518,10 @@ void RDMAEndpoint::enqueueImmRecvCompletion(ImmRecvContext* ctx)
             // than blocking indefinitely.
             completed_imm_recv_events_.push_back(event);
         }
-        pending_imm_recv_refill_.push_back(ctx);
     }
+
+    // Lock-free push to refill stack — outside any lock.
+    pushRefill(ctx);
 
     if (op_state) {
         completeImmRecvOp(op_state, event);
@@ -734,7 +753,7 @@ std::shared_ptr<ImmRecvFuture> RDMAEndpoint::immRecv(void* stream)
 
     std::optional<ImmRecvEvent> ready_event;
     {
-        std::lock_guard<std::mutex> guard(imm_recv_mutex_);
+        std::lock_guard<SpinLock> guard(imm_recv_match_lock_);
         if (!completed_imm_recv_events_.empty()) {
             ready_event = completed_imm_recv_events_.front();
             completed_imm_recv_events_.pop_front();
@@ -802,19 +821,14 @@ int32_t RDMAEndpoint::immRecvProcess()
 {
     int32_t work_done = 0;
 
-    // Repost completed transport slots. Keeping refill out of the CQ callback
-    // avoids mutating RDMAAssign while its callback is still executing.
-    while (true) {
-        ImmRecvContext* ctx = nullptr;
-        {
-            std::lock_guard<std::mutex> guard(imm_recv_mutex_);
-            if (pending_imm_recv_refill_.empty()) {
-                break;
-            }
-            ctx = pending_imm_recv_refill_.front();
-            pending_imm_recv_refill_.pop_front();
-        }
-        postImmRecvSlot(ctx);
+    // Atomically drain the entire lock-free refill stack in one exchange,
+    // then batch-repost all completed transport slots without any locking.
+    ImmRecvContext* batch = popAllRefill();
+    while (batch) {
+        ImmRecvContext* next = batch->next_refill_.load(std::memory_order_relaxed);
+        batch->next_refill_.store(nullptr, std::memory_order_relaxed);
+        postImmRecvSlot(batch);
+        batch = next;
         work_done++;
     }
 
@@ -1020,7 +1034,7 @@ int32_t RDMAEndpoint::process()
 void RDMAEndpoint::cancelAll()
 {
     {
-        std::lock_guard<std::mutex> guard(imm_recv_mutex_);
+        std::lock_guard<SpinLock> guard(imm_recv_match_lock_);
         for (auto& op_state : pending_imm_recv_ops_) {
             if (op_state) {
                 op_state->completion_status.store(RDMAAssign::FAILED, std::memory_order_release);
@@ -1031,8 +1045,10 @@ void RDMAEndpoint::cancelAll()
         }
         pending_imm_recv_ops_.clear();
         completed_imm_recv_events_.clear();
-        pending_imm_recv_refill_.clear();
     }
+
+    // Drain the lock-free refill stack.
+    popAllRefill();
 
     for (int i = 0; i < SLIME_MAX_IO_FIFO_DEPTH; ++i) {
         if (read_write_ctx_pool_) {

--- a/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
+++ b/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
@@ -507,7 +507,7 @@ void RDMAEndpoint::enqueueImmRecvCompletion(ImmRecvContext* ctx)
             op_state = std::move(pending_imm_recv_ops_.front());
             pending_imm_recv_ops_.pop_front();
         }
-        else if (event.status == RDMAAssign::SUCCESS) {
+        else {
             completed_imm_recv_events_.push_back(event);
         }
         pending_imm_recv_refill_.push_back(ctx);

--- a/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
+++ b/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <atomic>
-#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -35,17 +34,6 @@
 #include "rdma_worker_pool.h"
 
 namespace dlslime {
-
-namespace {
-
-uint64_t monotonic_time_ns()
-{
-    return static_cast<uint64_t>(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
-            .count());
-}
-
-}  // namespace
 
 // ============================================================
 // Constructor & Setup

--- a/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
+++ b/dlslime/csrc/engine/rdma/rdma_endpoint.cpp
@@ -508,6 +508,9 @@ void RDMAEndpoint::enqueueImmRecvCompletion(ImmRecvContext* ctx)
             pending_imm_recv_ops_.pop_front();
         }
         else {
+            // Queue all events (SUCCESS, FAILED, FLUSH) so that a future
+            // immRecv() caller observes the actual completion status rather
+            // than blocking indefinitely.
             completed_imm_recv_events_.push_back(event);
         }
         pending_imm_recv_refill_.push_back(ctx);

--- a/dlslime/csrc/engine/rdma/rdma_endpoint.h
+++ b/dlslime/csrc/engine/rdma/rdma_endpoint.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <deque>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -77,9 +78,23 @@ struct ImmRecvContext {
     std::shared_ptr<dlslime::device::DeviceSignal> signal;
     std::vector<RDMAAssign>                        assigns_;
 
-    uint32_t             expected_mask;
-    std::atomic<int32_t> completion_status{0};
-    IOContextState       state_ = IOContextState::FREE;
+    uint32_t              expected_mask;
+    std::atomic<uint32_t> finished_qp_mask{0};
+    std::atomic<int32_t>  completion_status{0};
+    std::atomic<int32_t>  imm_data{0};
+    IOContextState        state_ = IOContextState::FREE;
+};
+
+struct ImmRecvOpState {
+    std::shared_ptr<dlslime::device::DeviceSignal> signal;
+    uint32_t                                       expected_mask{0};
+    std::atomic<int32_t>                           completion_status{RDMAAssign::SUCCESS};
+    std::atomic<int32_t>                           imm_data{0};
+};
+
+struct ImmRecvEvent {
+    int32_t status{RDMAAssign::SUCCESS};
+    int32_t imm_data{0};
 };
 
 // ============================================================
@@ -252,6 +267,10 @@ private:
     // Private Methods - IO Operations
     // ============================================================
     void dummyReset(ImmRecvContext* ctx);
+    void postImmRecvSlot(ImmRecvContext* ctx);
+    void postImmRecvWindow();
+    void completeImmRecvOp(const std::shared_ptr<ImmRecvOpState>& op_state, const ImmRecvEvent& event);
+    void enqueueImmRecvCompletion(ImmRecvContext* ctx);
 
     int32_t
     dispatchTask(OpCode op_code, const std::vector<assign_tuple_t>&, int32_t imm_data = 0, void* stream = nullptr);
@@ -289,7 +308,6 @@ private:
     ImmRecvContext*   imm_recv_ctx_pool_;
 
     std::vector<std::shared_ptr<ReadWriteFuture>> read_write_future_pool_;
-    std::vector<std::shared_ptr<ImmRecvFuture>>   imm_recv_future_pool_;
 
     jring_t* read_write_buffer_ring_;
     jring_t* imm_recv_buffer_ring_;
@@ -299,10 +317,11 @@ private:
     std::atomic<uint64_t> rw_slot_id_{0};
     std::atomic<uint64_t> io_recv_slot_id_{0};
 
-    // Track how many Recvs we have actually posted to HW
-    std::atomic<uint64_t> posted_recv_cnt_{0};
-
-    std::atomic<int32_t> token_bucket_[64];
+    std::atomic<int32_t>                        token_bucket_[64];
+    std::mutex                                  imm_recv_mutex_;
+    std::deque<std::shared_ptr<ImmRecvOpState>> pending_imm_recv_ops_;
+    std::deque<ImmRecvEvent>                    completed_imm_recv_events_;
+    std::deque<ImmRecvContext*>                 pending_imm_recv_refill_;
 
     // Scratchpad buffers
     void*    io_burst_buf_[IO_BURST_SIZE];

--- a/dlslime/csrc/engine/rdma/rdma_endpoint.h
+++ b/dlslime/csrc/engine/rdma/rdma_endpoint.h
@@ -96,13 +96,16 @@ struct ImmRecvOpState {
     uint32_t                                       expected_mask{0};
     std::atomic<int32_t>                           completion_status{RDMAAssign::SUCCESS};
     std::atomic<int32_t>                           imm_data{0};
+    std::atomic<uint64_t>                          trace_start_ns{0};
+    std::atomic<uint64_t>                          trace_end_ns{0};
 };
 
 struct ImmRecvEvent {
     // Small value object that bridges transport completions and user receives.
     // It may be queued briefly if a WRITE_WITH_IMM arrives before immRecv().
-    int32_t status{RDMAAssign::SUCCESS};
-    int32_t imm_data{0};
+    int32_t  status{RDMAAssign::SUCCESS};
+    int32_t  imm_data{0};
+    uint64_t trace_end_ns{0};
 };
 
 // ============================================================

--- a/dlslime/csrc/engine/rdma/rdma_endpoint.h
+++ b/dlslime/csrc/engine/rdma/rdma_endpoint.h
@@ -14,6 +14,7 @@
 #include "dlslime/csrc/device/device_api.h"
 #include "dlslime/csrc/device/signal.h"
 #include "dlslime/csrc/engine/assignment.h"
+#include "dlslime/csrc/utils.h"
 #include "memory_pool.h"
 #include "rdma_assignment.h"
 #include "rdma_channel.h"
@@ -86,6 +87,9 @@ struct ImmRecvContext {
     std::atomic<int32_t>  completion_status{0};
     std::atomic<int32_t>  imm_data{0};
     IOContextState        state_ = IOContextState::FREE;
+
+    // Intrusive pointer for lock-free MPSC refill stack.
+    std::atomic<ImmRecvContext*> next_refill_{nullptr};
 };
 
 struct ImmRecvOpState {
@@ -283,6 +287,10 @@ private:
     void completeImmRecvOp(const std::shared_ptr<ImmRecvOpState>& op_state, const ImmRecvEvent& event);
     void enqueueImmRecvCompletion(ImmRecvContext* ctx);
 
+    /// Lock-free MPSC helpers for the refill stack.
+    void            pushRefill(ImmRecvContext* ctx);
+    ImmRecvContext* popAllRefill();
+
     int32_t
     dispatchTask(OpCode op_code, const std::vector<assign_tuple_t>&, int32_t imm_data = 0, void* stream = nullptr);
 
@@ -329,14 +337,16 @@ private:
     std::atomic<uint64_t> io_recv_slot_id_{0};
 
     std::atomic<int32_t> token_bucket_[64];
-    std::mutex           imm_recv_mutex_;
-    // Matching queues for the decoupled imm-recv path:
-    // - pending_imm_recv_ops_: user immRecv() calls waiting for a completion
-    // - completed_imm_recv_events_: completions that arrived before immRecv()
-    // - pending_imm_recv_refill_: transport slots ready to be reposted
+
+    // Matching queues for the decoupled imm-recv path.
+    // Protected by imm_recv_match_lock_ (spinlock, short critical sections).
+    SpinLock                                    imm_recv_match_lock_;
     std::deque<std::shared_ptr<ImmRecvOpState>> pending_imm_recv_ops_;
     std::deque<ImmRecvEvent>                    completed_imm_recv_events_;
-    std::deque<ImmRecvContext*>                 pending_imm_recv_refill_;
+
+    // Lock-free MPSC refill stack. CQ callback threads push via pushRefill(),
+    // the progress thread drains via popAllRefill(). No lock needed.
+    std::atomic<ImmRecvContext*> refill_head_{nullptr};
 
     // Scratchpad buffers
     void*    io_burst_buf_[IO_BURST_SIZE];

--- a/dlslime/csrc/engine/rdma/rdma_endpoint.h
+++ b/dlslime/csrc/engine/rdma/rdma_endpoint.h
@@ -78,6 +78,9 @@ struct ImmRecvContext {
     std::shared_ptr<dlslime::device::DeviceSignal> signal;
     std::vector<RDMAAssign>                        assigns_;
 
+    // Transport-owned receive slot. These contexts are kept posted on the
+    // hardware RQ and recycled after completion; user futures must not retain
+    // pointers to them because the slot can be refilled and reused.
     uint32_t              expected_mask;
     std::atomic<uint32_t> finished_qp_mask{0};
     std::atomic<int32_t>  completion_status{0};
@@ -86,6 +89,9 @@ struct ImmRecvContext {
 };
 
 struct ImmRecvOpState {
+    // User-owned state for one immRecv() call. A completion event is copied
+    // here when it is matched to this operation, so wait()/immData() remain
+    // stable even after the transport slot is reposted.
     std::shared_ptr<dlslime::device::DeviceSignal> signal;
     uint32_t                                       expected_mask{0};
     std::atomic<int32_t>                           completion_status{RDMAAssign::SUCCESS};
@@ -93,6 +99,8 @@ struct ImmRecvOpState {
 };
 
 struct ImmRecvEvent {
+    // Small value object that bridges transport completions and user receives.
+    // It may be queued briefly if a WRITE_WITH_IMM arrives before immRecv().
     int32_t status{RDMAAssign::SUCCESS};
     int32_t imm_data{0};
 };
@@ -317,8 +325,12 @@ private:
     std::atomic<uint64_t> rw_slot_id_{0};
     std::atomic<uint64_t> io_recv_slot_id_{0};
 
-    std::atomic<int32_t>                        token_bucket_[64];
-    std::mutex                                  imm_recv_mutex_;
+    std::atomic<int32_t> token_bucket_[64];
+    std::mutex           imm_recv_mutex_;
+    // Matching queues for the decoupled imm-recv path:
+    // - pending_imm_recv_ops_: user immRecv() calls waiting for a completion
+    // - completed_imm_recv_events_: completions that arrived before immRecv()
+    // - pending_imm_recv_refill_: transport slots ready to be reposted
     std::deque<std::shared_ptr<ImmRecvOpState>> pending_imm_recv_ops_;
     std::deque<ImmRecvEvent>                    completed_imm_recv_events_;
     std::deque<ImmRecvContext*>                 pending_imm_recv_refill_;

--- a/dlslime/csrc/engine/rdma/rdma_env.h
+++ b/dlslime/csrc/engine/rdma/rdma_env.h
@@ -25,4 +25,5 @@ inline const int SLIME_AGG_QP_NUM           = get_env<int>("SLIME_AGG_QP_NUM", 1
 inline const int SLIME_BYPASS_DEVICE_SIGNAL = get_env<int>("SLIME_BYPASS_DEVICE_SIGNAL", 1);
 inline const int SLIME_MAX_MSG_FIFO_DEPTH   = get_env<int>("SLIME_MAX_MSG_FIFO_DEPTH", 1024);
 inline const int SLIME_MAX_IO_FIFO_DEPTH    = get_env<int>("SLIME_MAX_IO_FIFO_DEPTH", 2048);
+inline const int SLIME_WITH_TIME_TRACE      = get_env<int>("SLIME_WITH_TIME_TRACE", get_env<int>("WITH_TIME_TRACE", 1));
 }  // namespace dlslime

--- a/dlslime/csrc/engine/rdma/rdma_env.h
+++ b/dlslime/csrc/engine/rdma/rdma_env.h
@@ -25,5 +25,5 @@ inline const int SLIME_AGG_QP_NUM           = get_env<int>("SLIME_AGG_QP_NUM", 1
 inline const int SLIME_BYPASS_DEVICE_SIGNAL = get_env<int>("SLIME_BYPASS_DEVICE_SIGNAL", 1);
 inline const int SLIME_MAX_MSG_FIFO_DEPTH   = get_env<int>("SLIME_MAX_MSG_FIFO_DEPTH", 1024);
 inline const int SLIME_MAX_IO_FIFO_DEPTH    = get_env<int>("SLIME_MAX_IO_FIFO_DEPTH", 2048);
-inline const int SLIME_WITH_TIME_TRACE      = get_env<int>("SLIME_WITH_TIME_TRACE", get_env<int>("WITH_TIME_TRACE", 1));
+inline const int SLIME_WITH_TIME_TRACE      = get_env<int>("SLIME_WITH_TIME_TRACE", 1);
 }  // namespace dlslime

--- a/dlslime/csrc/engine/rdma/rdma_future.cpp
+++ b/dlslime/csrc/engine/rdma/rdma_future.cpp
@@ -68,7 +68,7 @@ int32_t ImmRecvFuture::wait() const
     if (op_state_->signal) {
         op_state_->signal->wait_comm_done_cpu(op_state_->expected_mask);
     }
-    return 0;
+    return static_cast<int32_t>(op_state_->completion_status.load(std::memory_order_acquire));
 }
 
 int32_t ImmRecvFuture::immData() const

--- a/dlslime/csrc/engine/rdma/rdma_future.cpp
+++ b/dlslime/csrc/engine/rdma/rdma_future.cpp
@@ -55,27 +55,24 @@ int32_t ReadWriteFuture::wait() const
     return 0;
 }
 
-ImmRecvFuture::ImmRecvFuture(ImmRecvContext* ctx): ctx_(std::move(ctx))
+ImmRecvFuture::ImmRecvFuture(std::shared_ptr<ImmRecvOpState> op_state): op_state_(std::move(op_state))
 {
-    if (!ctx_) {
+    if (!op_state_) {
         throw std::runtime_error("ImmFuture created with null context");
     }
 }
 
 int32_t ImmRecvFuture::wait() const
 {
-    if (ctx_->signal) {
-        ctx_->signal->wait_comm_done_cpu(ctx_->expected_mask);
-    }
-    if (ctx_->completion_status.load() != RDMAAssign::SUCCESS) {
-        throw std::runtime_error("RDMA imm recv completion failed");
+    if (op_state_->signal) {
+        op_state_->signal->wait_comm_done_cpu(op_state_->expected_mask);
     }
     return 0;
 }
 
 int32_t ImmRecvFuture::immData() const
 {
-    return ctx_->assigns_[0].imm_data_;
+    return op_state_->imm_data.load(std::memory_order_acquire);
 }
 
 }  // namespace dlslime

--- a/dlslime/csrc/engine/rdma/rdma_future.cpp
+++ b/dlslime/csrc/engine/rdma/rdma_future.cpp
@@ -59,7 +59,7 @@ int32_t ReadWriteFuture::wait() const
 ImmRecvFuture::ImmRecvFuture(std::shared_ptr<ImmRecvOpState> op_state): op_state_(std::move(op_state))
 {
     if (!op_state_) {
-        throw std::runtime_error("ImmFuture created with null context");
+        throw std::runtime_error("ImmRecvFuture created with null ImmRecvOpState");
     }
 }
 

--- a/dlslime/csrc/engine/rdma/rdma_future.cpp
+++ b/dlslime/csrc/engine/rdma/rdma_future.cpp
@@ -4,6 +4,7 @@
 
 #include "dlslime/csrc/device/signal.h"
 #include "rdma_endpoint.h"
+#include "rdma_env.h"
 
 namespace dlslime {
 
@@ -73,6 +74,31 @@ int32_t ImmRecvFuture::wait() const
 int32_t ImmRecvFuture::immData() const
 {
     return op_state_->imm_data.load(std::memory_order_acquire);
+}
+
+bool ImmRecvFuture::timeTraceEnabled() const
+{
+    return SLIME_WITH_TIME_TRACE != 0;
+}
+
+uint64_t ImmRecvFuture::timeTraceStartNs() const
+{
+    return op_state_->trace_start_ns.load(std::memory_order_acquire);
+}
+
+uint64_t ImmRecvFuture::timeTraceEndNs() const
+{
+    return op_state_->trace_end_ns.load(std::memory_order_acquire);
+}
+
+uint64_t ImmRecvFuture::timeTraceElapsedNs() const
+{
+    uint64_t start_ns = timeTraceStartNs();
+    uint64_t end_ns   = timeTraceEndNs();
+    if (start_ns == 0 || end_ns <= start_ns) {
+        return 0;
+    }
+    return end_ns - start_ns;
 }
 
 }  // namespace dlslime

--- a/dlslime/csrc/engine/rdma/rdma_future.h
+++ b/dlslime/csrc/engine/rdma/rdma_future.h
@@ -11,13 +11,14 @@ struct SendContext;
 struct RecvContext;
 struct ReadWriteContext;
 struct ImmRecvContext;
+struct ImmRecvOpState;
 
 /**
  * @brief Base class for RDMA futures, inherits from DeviceFuture
  *
  * Provides consistent interface with other device types (Ascend, NVLink)
  */
-class RDMAFuture : public DeviceFuture {
+class RDMAFuture: public DeviceFuture {
 public:
     virtual ~RDMAFuture() = default;
 
@@ -61,14 +62,14 @@ private:
 
 class ImmRecvFuture: public RDMAFuture {
 public:
-    explicit ImmRecvFuture(ImmRecvContext* ctx);
+    explicit ImmRecvFuture(std::shared_ptr<ImmRecvOpState> op_state);
 
     int32_t wait() const override;
 
     int32_t immData() const;
 
 private:
-    ImmRecvContext* ctx_;
+    std::shared_ptr<ImmRecvOpState> op_state_;
 };
 
 }  // namespace dlslime

--- a/dlslime/csrc/engine/rdma/rdma_future.h
+++ b/dlslime/csrc/engine/rdma/rdma_future.h
@@ -66,7 +66,11 @@ public:
 
     int32_t wait() const override;
 
-    int32_t immData() const;
+    int32_t  immData() const;
+    bool     timeTraceEnabled() const;
+    uint64_t timeTraceStartNs() const;
+    uint64_t timeTraceEndNs() const;
+    uint64_t timeTraceElapsedNs() const;
 
 private:
     std::shared_ptr<ImmRecvOpState> op_state_;

--- a/dlslime/csrc/python/bind.cpp
+++ b/dlslime/csrc/python/bind.cpp
@@ -119,7 +119,13 @@ PYBIND11_MODULE(_slime_c, m)
         .def("wait", &dlslime::ReadWriteFuture::wait, py::call_guard<py::gil_scoped_release>());
     py::class_<dlslime::ImmRecvFuture, std::shared_ptr<dlslime::ImmRecvFuture>>(m, "SlimeImmRecvFuture")
         .def("wait", &dlslime::ImmRecvFuture::wait, py::call_guard<py::gil_scoped_release>())
-        .def("imm_data", &dlslime::ImmRecvFuture::immData, py::call_guard<py::gil_scoped_release>());
+        .def("imm_data", &dlslime::ImmRecvFuture::immData, py::call_guard<py::gil_scoped_release>())
+        .def("time_trace_enabled", &dlslime::ImmRecvFuture::timeTraceEnabled, py::call_guard<py::gil_scoped_release>())
+        .def("time_trace_start_ns", &dlslime::ImmRecvFuture::timeTraceStartNs, py::call_guard<py::gil_scoped_release>())
+        .def("time_trace_end_ns", &dlslime::ImmRecvFuture::timeTraceEndNs, py::call_guard<py::gil_scoped_release>())
+        .def("time_trace_elapsed_ns",
+             &dlslime::ImmRecvFuture::timeTraceElapsedNs,
+             py::call_guard<py::gil_scoped_release>());
     py::class_<dlslime::RDMAMemoryPool, std::shared_ptr<dlslime::RDMAMemoryPool>>(m, "RDMAMemoryPool")
         .def(py::init<std::shared_ptr<dlslime::RDMAContext>>(), py::arg("context"))
         .def(

--- a/dlslime/csrc/utils.h
+++ b/dlslime/csrc/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <stdexcept>
@@ -8,6 +9,24 @@
 #include "dlslime/csrc/common/jring.h"
 
 namespace dlslime {
+
+// ============================================================
+// SpinLock — lightweight alternative to std::mutex for short
+// critical sections (e.g. the imm-recv matching path).
+// ============================================================
+
+class SpinLock {
+    std::atomic_flag flag_ = ATOMIC_FLAG_INIT;
+
+public:
+    void lock() noexcept
+    {
+        while (flag_.test_and_set(std::memory_order_acquire)) {
+            // Spin. On x86 this compiles to a PAUSE-based loop.
+        }
+    }
+    void unlock() noexcept { flag_.clear(std::memory_order_release); }
+};
 
 inline jring_t* createRing(const char* name, size_t count)
 {

--- a/dlslime/csrc/utils.h
+++ b/dlslime/csrc/utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <chrono>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 
@@ -33,6 +35,13 @@ inline void freeRing(jring_t* ring)
     if (ring) {
         free(ring);
     }
+}
+
+inline uint64_t monotonic_time_ns()
+{
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
+            .count());
 }
 
 }  // namespace dlslime

--- a/dlslime/logging.py
+++ b/dlslime/logging.py
@@ -1,0 +1,59 @@
+"""Logging helpers for DLSlime.
+
+Library modules should get loggers through this module instead of configuring
+Python logging directly. Applications can opt in with:
+
+    import logging
+    import dlslime
+
+    dlslime.set_log_level(logging.INFO)
+"""
+
+from __future__ import annotations
+
+import logging as _logging
+
+_ROOT_LOGGER_NAME = "slime"
+_DEFAULT_FORMAT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
+
+
+def get_logger(name: str | None = None) -> _logging.Logger:
+    """Return a DLSlime logger.
+
+    Passing ``"rpc"`` returns ``"slime.rpc"``. Passing an already qualified
+    ``"slime.*"`` name returns it unchanged.
+    """
+    if not name:
+        logger_name = _ROOT_LOGGER_NAME
+    elif name == _ROOT_LOGGER_NAME or name.startswith(f"{_ROOT_LOGGER_NAME}."):
+        logger_name = name
+    else:
+        logger_name = f"{_ROOT_LOGGER_NAME}.{name}"
+    return _logging.getLogger(logger_name)
+
+
+def set_log_level(
+    level: int | str,
+    *,
+    logger_name: str = _ROOT_LOGGER_NAME,
+    configure_handler: bool = True,
+) -> _logging.Logger:
+    """Set the log level for DLSlime loggers.
+
+    ``configure_handler`` installs a stderr ``StreamHandler`` only when the
+    target logger has no handlers yet. This keeps DLSlime quiet by default while
+    making ``dlslime.set_log_level(logging.INFO)`` useful in scripts.
+    """
+    logger = get_logger(logger_name)
+    logger.setLevel(level)
+    has_real_handler = any(
+        not isinstance(handler, _logging.NullHandler) for handler in logger.handlers
+    )
+    if configure_handler and not has_real_handler:
+        handler = _logging.StreamHandler()
+        handler.setFormatter(_logging.Formatter(_DEFAULT_FORMAT))
+        logger.addHandler(handler)
+    return logger
+
+
+get_logger().addHandler(_logging.NullHandler())

--- a/dlslime/rpc/channel.py
+++ b/dlslime/rpc/channel.py
@@ -8,9 +8,13 @@ Wire format per message:
 """
 
 import ctypes
+import logging
 
 from dlslime import _slime_c
+from dlslime.logging import get_logger
 from .buffer import GrowableBuffer
+
+logger = get_logger("rpc")
 
 TAG_SIZE = 4  # u32 tag header
 
@@ -112,6 +116,17 @@ class Channel:
         future = self._ep.imm_recv()
         future.wait()
         total = future.imm_data()
+        if logger.isEnabledFor(logging.DEBUG) and hasattr(
+            future, "time_trace_elapsed_ns"
+        ):
+            elapsed_ns = future.time_trace_elapsed_ns()
+            logger.debug(
+                "RDMA imm_recv completed: total=%dB elapsed=%.3fus start_ns=%d end_ns=%d",
+                total,
+                elapsed_ns / 1000.0,
+                future.time_trace_start_ns(),
+                future.time_trace_end_ns(),
+            )
         if total < TAG_SIZE:
             raise ConnectionError(
                 f"RDMA channel closed (received {total}-byte completion, "

--- a/dlslime/rpc/service.py
+++ b/dlslime/rpc/service.py
@@ -1,12 +1,12 @@
 """serve() — worker-side event loop that dispatches incoming RPC calls."""
 
 import ctypes
-import logging
 
+from dlslime.logging import get_logger
 from .channel import Channel, FLAG_MASK, REPLY_BIT
 from .registry import MethodRegistry
 
-logger = logging.getLogger("slime.rpc")
+logger = get_logger("rpc")
 
 
 def _log_disconnect(message: str) -> None:


### PR DESCRIPTION
## Summary

Fix RDMA `ImmRecv` RNR handling by decoupling user-visible receive futures from transport receive slots.

This change pre-posts the IO immediate receive window after QP connection and refills receive slots after completions, so incoming `WRITE_WITH_IMM` operations no longer depend on the timing of user `imm_recv()` calls.

## Changes

- Pre-post `SLIME_MAX_IO_FIFO_DEPTH` immediate receive WRs when the IO channel connects.
- Refill completed immediate receive slots from `immRecvProcess()`.
- Introduce per-call `ImmRecvOpState` so `ImmRecvFuture` no longer reads reusable `ImmRecvContext` state.
- Queue completed immediate events when no user `imm_recv()` is currently waiting.
- Treat failed/flush immediate receive completions as disconnect-style completions instead of surfacing `RuntimeError` from `ImmRecvFuture::wait()`.

## Motivation

The previous implementation tied receive posting to user `imm_recv()` calls or a small user-driven pre-post window. Under fan-out or cleanup races, the receiver RQ could become empty or a flushed reusable slot could be observed by a future, causing RNR retries or `RDMA imm recv completion failed`.

This follows the eRPC/NCCL-style pattern more closely: keep receive WRs posted independently of application receive calls.

## Validation

- `pip install -v -e .`

Both completed successfully.