### PR TITLE
[PeerAgent] refine peer_agent api

### DIFF
--- a/bench/python/rpc_bench_slime_driver.py
+++ b/bench/python/rpc_bench_slime_driver.py
@@ -114,7 +114,7 @@ def main():
     # Only test sizes that fit in the buffer (payload must be < buffer size)
     sizes = [s for s in SIZES if s < buf_bytes and s <= max_size_bytes]
 
-    driver = PeerAgent(alias="bench-driver", server_url=args.ctrl, scope=args.scope)
+    driver = PeerAgent(nanoctrl_url=args.ctrl, alias="bench-driver", scope=args.scope)
     driver._rpc_buffer_size = buf_bytes
     driver._rpc_max_inflight = max(1, int(getattr(args, "max_inflight", 4)))
 

--- a/bench/python/rpc_bench_slime_worker.py
+++ b/bench/python/rpc_bench_slime_worker.py
@@ -61,7 +61,7 @@ def main():
     )
     args = parser.parse_args()
 
-    worker = PeerAgent(alias="bench-worker", server_url=args.ctrl, scope=args.scope)
+    worker = PeerAgent(nanoctrl_url=args.ctrl, alias="bench-worker", scope=args.scope)
     worker._rpc_buffer_size = args.buf_mb * 1024 * 1024
     # Bench uses single-flight RPCs; cap max_inflight so we don't pin
     # buf_mb * SLIME_RPC_MAX_INFLIGHT bytes of CPU memory needlessly.

--- a/dlslime/cache/cli.py
+++ b/dlslime/cache/cli.py
@@ -392,14 +392,11 @@ def _make_peer_agent(cfg):
     peer_agent_alias = cfg.peer_agent_alias
     if peer_agent_alias is None:
         peer_agent_alias = f"{str(cfg.service_id).replace('cache:', 'cache-agent:', 1)}"
-    server_url = cfg.peer_agent_ctrl or cfg.ctrl or "http://127.0.0.1:3000"
+    nanoctrl_url = cfg.peer_agent_ctrl or cfg.ctrl or "http://127.0.0.1:3000"
     return PeerAgent(
+        nanoctrl_url=nanoctrl_url,
         alias=peer_agent_alias,
-        server_url=server_url,
         device=cfg.peer_agent_device,
-        ib_port=cfg.peer_agent_ib_port,
-        link_type=cfg.peer_agent_link_type,
-        qp_num=cfg.peer_agent_qp_num,
         scope=cfg.scope,
     )
 

--- a/dlslime/cache/client.py
+++ b/dlslime/cache/client.py
@@ -133,30 +133,28 @@ class CacheClient:
         server_alias = str(info["peer_agent_id"])
         agent = peer_agent or self.peer_agent
 
-        if agent is None or not hasattr(agent, "set_desired_topology"):
-            server_url = ctrl or info.get("ctrl")
-            if not server_url:
+        if agent is None or not hasattr(agent, "connect_to"):
+            nanoctrl_url = ctrl or info.get("nanoctrl_url")
+            if not nanoctrl_url:
                 raise RuntimeError("cache service did not publish a NanoCtrl address")
             from dlslime import PeerAgent
 
             agent = PeerAgent(
+                nanoctrl_url=nanoctrl_url,
                 alias=alias,
-                server_url=server_url,
                 device=local_device,
-                ib_port=ib_port,
-                qp_num=qp_num,
                 scope=scope if scope is not None else info.get("scope"),
             )
         self.peer_agent = agent
 
-        agent.set_desired_topology(
+        conn = agent.connect_to(
             server_alias,
             local_device=local_device,
             peer_device=peer_device,
             ib_port=ib_port,
             qp_num=qp_num,
         )
-        agent.wait_for_peers([server_alias], timeout_sec=timeout_sec)
+        conn.wait(timeout=timeout_sec)
         return info
 
     def default_peer_agent_id(self) -> str:

--- a/dlslime/cache/service.py
+++ b/dlslime/cache/service.py
@@ -98,15 +98,13 @@ class CacheService:
             raise RuntimeError(
                 "cache service was started without preallocated cache memory"
             )
-        resource = None
-        if hasattr(self.peer_agent, "query_resource"):
-            resource = self.peer_agent.query_resource(alias)
+        resource = self.peer_agent.get_resource()
         return {
             "peer_agent_id": alias,
             "cache_mr_name": self.cache_mr_name,
             "cache_mr_handle": self.cache_mr_handle,
-            "ctrl": getattr(self.peer_agent, "server_url", None),
-            "scope": getattr(self.peer_agent, "redis_key_prefix", None) or None,
+            "nanoctrl_url": getattr(self.peer_agent, "nanoctrl_url", None),
+            "scope": getattr(self.peer_agent, "_redis_key_prefix", None) or None,
             "slab_size": self.slab_size,
             "memory_size": self.memory_size,
             "resource": resource,

--- a/dlslime/peer_agent/_agent.py
+++ b/dlslime/peer_agent/_agent.py
@@ -27,8 +27,17 @@ except ImportError as e:
 from nanoctrl import NanoCtrlClient
 
 from dlslime import discover_topology, RDMAContext, RDMAEndpoint, RDMAMemoryPool
+from dlslime.logging import get_logger
 from ._mailbox import StreamMailbox
 from ._obs import _tlog
+
+logger = get_logger("peer_agent")
+
+
+def _lifecycle_notice(message: str, *args: Any) -> None:
+    rendered = message % args if args else message
+    logger.info(rendered)
+    print(rendered, flush=True)
 
 
 @dataclass(frozen=True)
@@ -100,58 +109,105 @@ class DirectedConnection:
         self.state = "failed"
 
 
+class PeerConnection:
+    """Public handle for one peer connection."""
+
+    def __init__(self, agent: "PeerAgent", peer_alias: str) -> None:
+        self._agent = agent
+        self.peer_alias = peer_alias
+
+    def _connection(self) -> DirectedConnection:
+        with self._agent._connections_lock:
+            conn = self._agent._connections.get(self.peer_alias)
+        if conn is None:
+            raise RuntimeError(
+                f"Connection for {self.peer_alias} not found. "
+                "Call connect_to(peer, ...) first."
+            )
+        return conn
+
+    def wait(self, timeout: float = 60.0) -> "PeerConnection":
+        """Block until this peer connection is ready."""
+        self._agent._wait_connected(self.peer_alias, timeout_sec=timeout)
+        return self
+
+    def is_connected(self) -> bool:
+        """Return whether this peer is connected locally."""
+        return self._agent._is_peer_connected(self.peer_alias)
+
+    @property
+    def conn_id(self) -> str:
+        """Return the stable connection id."""
+        return self._connection().conn_id
+
+    @property
+    def local_nic(self) -> str:
+        """Return the local RDMA NIC selected for this connection."""
+        return self._connection().local_key.device
+
+    @property
+    def remote_nic(self) -> str:
+        """Return the peer RDMA NIC selected for this connection."""
+        return self._connection().peer_key.device
+
+    @property
+    def state(self) -> str:
+        """Return the current connection state."""
+        return self._connection().state
+
+    @property
+    def endpoint(self) -> Optional[RDMAEndpoint]:
+        """Return the selected endpoint once created, otherwise None."""
+        conn = self._connection()
+        if conn.endpoint is not None:
+            return conn.endpoint
+        with self._agent._endpoints_lock:
+            endpoint = self._agent._endpoints.get(self.peer_alias)
+        if endpoint is not None:
+            _, pool = self._agent._get_context_and_pool(conn.local_key)
+            conn.attach_endpoint(endpoint, pool)
+        return endpoint
+
+
 class PeerAgent:
     """PeerAgent manages RDMA connections via declarative topology reconciliation."""
 
     def __init__(
         self,
+        nanoctrl_url: str = "http://127.0.0.1:3000",
         alias: Optional[str] = None,
-        server_url: str = "http://127.0.0.1:3000",
         device: Optional[str] = None,
-        ib_port: int = 1,
-        link_type: Optional[str] = None,
-        qp_num: int = 1,
         scope: Optional[str] = None,
     ):
         """
         Initialize a PeerAgent.
 
         Args:
+            nanoctrl_url: URL of the control plane server (NanoCtrl)
             alias: (Optional) Agent name. If None, requests unique name from NanoCtrl.
-            server_url: URL of the control plane server (NanoCtrl)
             device: RDMA device name (e.g., "mlx5_0"), if None, auto-select
-            ib_port: InfiniBand port number
-            link_type: Optional compatibility override. Prefer topology discovery.
-            qp_num: Number of queue pairs per endpoint
             scope: Scope string for multi-tenant isolation (used as Redis key prefix).
         """
-        self.server_url = server_url
-        self.redis_address: Optional[str] = None
+        self.nanoctrl_url = nanoctrl_url
+        self._redis_address: Optional[str] = None
         self.alias: str = alias or ""
-        self.device = device
-        self.ib_port = ib_port
-        self.link_type = link_type
-        self.qp_num = qp_num
+        self._preferred_device = device
 
         # Build Redis key prefix from scope parameter
-        self.redis_key_prefix = scope or ""
+        self._redis_key_prefix = scope or ""
 
         # NanoCtrl HTTP client
-        self._client = NanoCtrlClient(server_url, scope=self.redis_key_prefix or None)
-
-        import socket
-
-        hostname = socket.gethostname()
-        local_ip = socket.gethostbyname(hostname)
-        self.address = local_ip
+        self._client = NanoCtrlClient(
+            nanoctrl_url, scope=self._redis_key_prefix or None
+        )
 
         # Local topology is discovered before registration and published through
         # NanoCtrl/Redis. RDMA resources are created lazily per selected
         # (device, port, link_type) instead of being bound to the whole agent.
         self._local_resource = self._discover_local_resource(
             preferred_device=device,
-            preferred_ib_port=ib_port,
-            preferred_link_type=link_type,
+            preferred_ib_port=1,
+            preferred_link_type=None,
         )
         self._resource_cache: Dict[str, Dict[str, Any]] = {}
         self._resource_cache_lock = threading.Lock()
@@ -162,7 +218,7 @@ class PeerAgent:
         )  # Protects _endpoints for concurrent reconcile
         self._connected_peers: Set[str] = set()
         self._connected_peers_lock = threading.Lock()
-        # Notified whenever _connected_peers changes, so `wait_for_peers`
+        # Notified whenever _connected_peers changes, so PeerConnection.wait()
         # can block on a condition instead of polling. Shares the existing
         # lock so is_peer_connected / mark_peer_connected call sites are
         # unchanged.
@@ -193,7 +249,7 @@ class PeerAgent:
         self._regions_lock = threading.Lock()
 
         # Worker pool for eager RDMAEndpoint construction in
-        # set_desired_topology. RDMAEndpoint() allocates QPs and takes
+        # connect_to. RDMAEndpoint() allocates QPs and takes
         # ~10-15 ms each; doing them serially on the mailbox listener
         # makes max_edge scale as O(num_peers) — moving the allocation
         # here instead, in parallel, keeps the listener's per-message
@@ -210,7 +266,7 @@ class PeerAgent:
         self._mr_info_cache_lock = threading.Lock()
 
         # Redis is discovered from NanoCtrl during registration.
-        self.redis_client: Optional[redis.Redis] = None
+        self._redis_client: Optional[redis.Redis] = None
 
         self._stop_event = threading.Event()
         self._shutdown_called = False
@@ -242,10 +298,18 @@ class PeerAgent:
     # Registration / lifecycle
     # ------------------------------------------------------------------
     def _redis_prefix(self) -> str:
-        return f"{self.redis_key_prefix}:" if self.redis_key_prefix else ""
+        return f"{self._redis_key_prefix}:" if self._redis_key_prefix else ""
 
     def _agent_key(self, alias: str) -> str:
         return f"{self._redis_prefix()}agent:{alias}"
+
+    def _local_address(self) -> str:
+        host = self._local_resource.get("host")
+        if isinstance(host, dict):
+            address = host.get("address")
+            if address:
+                return str(address)
+        return ""
 
     def _normalize_link_type(self, link_type: Optional[str]) -> str:
         if not link_type:
@@ -326,7 +390,9 @@ class PeerAgent:
         max_retries = 5
         retry_delay = 1.0
 
-        print(f"PeerAgent: Registering with control plane at {self.server_url}")
+        _lifecycle_notice(
+            "PeerAgent: Registering with control plane at %s", self.nanoctrl_url
+        )
 
         for attempt in range(max_retries):
             try:
@@ -335,16 +401,16 @@ class PeerAgent:
                 # Extract allocated name from response
                 if "name" in result:
                     self.alias = result["name"]
-                    print(f"PeerAgent: Registered with name: {self.alias}")
+                    _lifecycle_notice("PeerAgent: Registered with name: %s", self.alias)
                 else:
                     raise RuntimeError("NanoCtrl did not return agent name")
 
                 if "redis_address" not in result:
                     raise RuntimeError("NanoCtrl did not return redis_address")
 
-                self.redis_address = result["redis_address"]
-                redis_host, redis_port = self.redis_address.split(":")
-                self.redis_client = redis.Redis(
+                self._redis_address = result["redis_address"]
+                redis_host, redis_port = self._redis_address.split(":")
+                self._redis_client = redis.Redis(
                     host=redis_host, port=int(redis_port), decode_responses=True
                 )
                 self._publish_resource_record()
@@ -356,13 +422,21 @@ class PeerAgent:
             ) as e:
                 if attempt < max_retries - 1:
                     wait_time = retry_delay * (2**attempt)
-                    print(
-                        f"PeerAgent {self.alias} registration failed (attempt {attempt + 1}/{max_retries}): {e}. Retrying in {wait_time:.1f}s..."
+                    logger.warning(
+                        "PeerAgent %s registration failed (attempt %s/%s): %s. "
+                        "Retrying in %.1fs...",
+                        self.alias,
+                        attempt + 1,
+                        max_retries,
+                        e,
+                        wait_time,
                     )
                     time.sleep(wait_time)
                 else:
-                    print(
-                        f"PeerAgent {self.alias} registration failed after {max_retries} attempts"
+                    logger.error(
+                        "PeerAgent %s registration failed after %s attempts",
+                        self.alias,
+                        max_retries,
                     )
                     raise
 
@@ -371,7 +445,7 @@ class PeerAgent:
         params = inspect.signature(self._client.register_peer).parameters
         kwargs: Dict[str, Any] = {
             "alias": self.alias or None,
-            "address": self.address,
+            "address": self._local_address(),
         }
 
         if "resource" in params:
@@ -380,9 +454,9 @@ class PeerAgent:
         if {"device", "ib_port", "link_type", "name_prefix"} & set(params):
             key = self._first_usable_resource_key(
                 self._local_resource,
-                device=self.device,
-                ib_port=self.ib_port,
-                link_type=self.link_type,
+                device=self._preferred_device,
+                ib_port=1,
+                link_type=None,
             )
             if "device" in params:
                 kwargs["device"] = key.device
@@ -396,16 +470,16 @@ class PeerAgent:
         return self._client.register_peer(**kwargs)
 
     def _publish_resource_record(self) -> None:
-        if self.redis_client is None or not self.alias:
+        if self._redis_client is None or not self.alias:
             return
         memory_keys = sorted(self._logical_regions.keys())
         self._local_resource["memory_keys"] = memory_keys
         key = self._agent_key(self.alias)
         try:
-            self.redis_client.hset(
+            self._redis_client.hset(
                 key,
                 mapping={
-                    "addr": self.address,
+                    "addr": self._local_address(),
                     "resource": json.dumps(self._local_resource),
                     "topology": json.dumps(self._local_resource),
                     "memory_keys": json.dumps(memory_keys),
@@ -413,34 +487,36 @@ class PeerAgent:
                 },
             )
         except Exception as e:
-            print(f"PeerAgent {self.alias}: Resource publish warning: {e}")
+            logger.warning("PeerAgent %s: Resource publish warning: %s", self.alias, e)
 
-    def query_active_agent(self) -> List[str]:
+    def list_agents(self) -> List[str]:
         """Return active peer aliases in the same scope from Redis."""
-        if self.redis_client is None:
+        if self._redis_client is None:
             return []
         prefix = self._redis_prefix()
         pattern = f"{prefix}agent:*"
         key_prefix = f"{prefix}agent:"
         active: List[str] = []
-        for key in self.redis_client.scan_iter(match=pattern, count=200):
-            ttl = self.redis_client.ttl(key)
+        for key in self._redis_client.scan_iter(match=pattern, count=200):
+            ttl = self._redis_client.ttl(key)
             if ttl == 0 or ttl == -2:
                 continue
             active.append(str(key).removeprefix(key_prefix))
         return sorted(active)
 
-    def query_resource(self, peer_alias: str) -> Optional[Dict[str, Any]]:
-        """Read a peer's published topology/resource JSON from Redis."""
-        if peer_alias == self.alias:
+    def get_resource(
+        self, peer_alias: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Return local resource or read a peer's published resource from Redis."""
+        if peer_alias is None or peer_alias == self.alias:
             return self._local_resource
         with self._resource_cache_lock:
             cached = self._resource_cache.get(peer_alias)
             if cached is not None:
                 return cached
-        if self.redis_client is None:
+        if self._redis_client is None:
             return None
-        record = self.redis_client.hgetall(self._agent_key(peer_alias))
+        record = self._redis_client.hgetall(self._agent_key(peer_alias))
         if not record:
             return None
         raw = record.get("resource") or record.get("topology")
@@ -474,14 +550,14 @@ class PeerAgent:
                 self._resource_cache[peer_alias] = resource
         return resource
 
-    def query_mem_keys(self, peer_alias: Optional[str] = None) -> List[str]:
+    def list_mem_keys(self, peer_alias: Optional[str] = None) -> List[str]:
         """Return local or peer logical memory region names."""
         if peer_alias is None or peer_alias == self.alias:
             with self._regions_lock:
                 return sorted(self._logical_regions.keys())
-        if self.redis_client is None:
+        if self._redis_client is None:
             return []
-        record = self.redis_client.hgetall(self._agent_key(peer_alias))
+        record = self._redis_client.hgetall(self._agent_key(peer_alias))
         raw = record.get("memory_keys") if record else None
         if raw:
             try:
@@ -495,7 +571,7 @@ class PeerAgent:
         pattern = f"{prefix}mr:{peer_alias}:*"
         keys = []
         mr_prefix = f"{prefix}mr:{peer_alias}:"
-        for key in self.redis_client.scan_iter(match=pattern, count=200):
+        for key in self._redis_client.scan_iter(match=pattern, count=200):
             suffix = str(key).removeprefix(mr_prefix)
             keys.append(suffix.split(":", 1)[0])
         return sorted(set(keys))
@@ -503,19 +579,21 @@ class PeerAgent:
     def _start_cleanup_listener(self) -> None:
         """Listen for cleanup events from peers (NanoCtrl pushes to inbox)."""
         # Flush any stale events left by a previous run so we don't act on them.
-        inbox_key = f"{self.redis_key_prefix}:inbox:{self.alias}"
-        self.redis_client.delete(inbox_key)
+        inbox_key = f"{self._redis_key_prefix}:inbox:{self.alias}"
+        self._redis_client.delete(inbox_key)
 
         def event_loop():
             while not self._stop_event.is_set():
                 try:
-                    result = self.redis_client.blpop(inbox_key, timeout=1)
+                    result = self._redis_client.blpop(inbox_key, timeout=1)
                     if result:
                         _, event_str = result
                         event = json.loads(event_str)
                         if event.get("type") == "cleanup":
                             peer = event.get("peer")
-                            print(f"PeerAgent {self.alias}: Cleanup from peer {peer}")
+                            logger.info(
+                                "PeerAgent %s: Cleanup from peer %s", self.alias, peer
+                            )
                             with self._endpoints_lock:
                                 if peer in self._endpoints:
                                     # Force-complete any blocked RDMA waits before
@@ -528,15 +606,19 @@ class PeerAgent:
                                     with self._connected_peers_lock:
                                         self._connected_peers.discard(peer)
                                         self._connected_peers_cond.notify_all()
-                                    self.clear_peer_notified(peer)
+                                    self._clear_peer_notified(peer)
                                     del self._endpoints[peer]
-                                    print(
-                                        f"PeerAgent {self.alias}: Removed endpoint for {peer}"
+                                    logger.info(
+                                        "PeerAgent %s: Removed endpoint for %s",
+                                        self.alias,
+                                        peer,
                                     )
                 except redis.exceptions.ConnectionError:
                     time.sleep(0.1)
                 except Exception as e:
-                    print(f"PeerAgent {self.alias}: Cleanup listener error: {e}")
+                    logger.warning(
+                        "PeerAgent %s: Cleanup listener error: %s", self.alias, e
+                    )
                     time.sleep(0.1)
 
         self._event_thread = threading.Thread(target=event_loop, daemon=True)
@@ -552,7 +634,7 @@ class PeerAgent:
         if not self.alias:
             return
 
-        prefix = f"{self.redis_key_prefix}:" if self.redis_key_prefix else ""
+        prefix = f"{self._redis_key_prefix}:" if self._redis_key_prefix else ""
         patterns = [
             f"{prefix}exchange:{self.alias}:*",
             f"{prefix}exchange:*:{self.alias}",
@@ -561,12 +643,12 @@ class PeerAgent:
             keys_to_delete: list[str] = []
             for pattern in patterns:
                 keys_to_delete.extend(
-                    list(self.redis_client.scan_iter(match=pattern, count=200))
+                    list(self._redis_client.scan_iter(match=pattern, count=200))
                 )
             if keys_to_delete:
-                self.redis_client.delete(*keys_to_delete)
+                self._redis_client.delete(*keys_to_delete)
         except Exception as e:
-            print(f"PeerAgent {self.alias}: Exchange cleanup warning: {e}")
+            logger.warning("PeerAgent %s: Exchange cleanup warning: %s", self.alias, e)
 
     def _cleanup_stale_mr_keys(self) -> None:
         """Delete stale Redis MR keys registered by a previous run of this alias.
@@ -579,14 +661,16 @@ class PeerAgent:
         if not self.alias:
             return
 
-        prefix = f"{self.redis_key_prefix}:" if self.redis_key_prefix else ""
+        prefix = f"{self._redis_key_prefix}:" if self._redis_key_prefix else ""
         pattern = f"{prefix}mr:{self.alias}:*"
         try:
-            keys_to_delete = list(self.redis_client.scan_iter(match=pattern, count=200))
+            keys_to_delete = list(
+                self._redis_client.scan_iter(match=pattern, count=200)
+            )
             if keys_to_delete:
-                self.redis_client.delete(*keys_to_delete)
+                self._redis_client.delete(*keys_to_delete)
         except Exception as e:
-            print(f"PeerAgent {self.alias}: MR cleanup warning: {e}")
+            logger.warning("PeerAgent %s: MR cleanup warning: %s", self.alias, e)
 
     def _start_heartbeat(self, interval: float = 15.0) -> None:
         """Periodically POST /heartbeat to refresh agent TTL in NanoCtrl."""
@@ -599,13 +683,14 @@ class PeerAgent:
                 try:
                     resp = self._client.heartbeat_peer(self.alias)
                     if resp.get("status") == "not_found":
-                        print(
-                            f"PeerAgent {self.alias}: Heartbeat returned not_found, "
-                            f"re-registering..."
+                        logger.warning(
+                            "PeerAgent %s: Heartbeat returned not_found, "
+                            "re-registering...",
+                            self.alias,
                         )
                         self._register()
                 except Exception as e:
-                    print(f"PeerAgent {self.alias}: Heartbeat failed: {e}")
+                    logger.warning("PeerAgent %s: Heartbeat failed: %s", self.alias, e)
 
         self._heartbeat_thread = threading.Thread(target=heartbeat_loop, daemon=True)
         self._heartbeat_thread.start()
@@ -622,7 +707,7 @@ class PeerAgent:
         link_type: Optional[str],
         fallback_device: Optional[str],
     ) -> RdmaResourceKey:
-        peer_resource = self.query_resource(peer_alias)
+        peer_resource = self.get_resource(peer_alias)
         if peer_resource is not None:
             return self._first_usable_resource_key(
                 peer_resource,
@@ -636,7 +721,7 @@ class PeerAgent:
             ib_port=ib_port,
             link_type=link_type,
         )
-        fallback_link = link_type or self.link_type or fallback_local.link_type
+        fallback_link = link_type or fallback_local.link_type
         return RdmaResourceKey(
             peer_device or fallback_device or fallback_local.device,
             int(ib_port or 1),
@@ -663,14 +748,16 @@ class PeerAgent:
                     raise RuntimeError(
                         f"Multiple directed connections to {peer_alias} are not "
                         "supported by the first PeerAgent implementation. "
-                        "Use query_endpoint(peer, local_device, peer_device, ...) "
-                        "to select an established data-plane endpoint."
+                        "Use get_connections() to inspect established "
+                        "connections."
                     )
                 return existing
 
             if local_key is None:
                 local_key = self._first_usable_resource_key(
-                    self._local_resource, ib_port=self.ib_port, link_type=self.link_type
+                    self._local_resource,
+                    ib_port=1,
+                    link_type=None,
                 )
             if peer_key is None:
                 peer_key = RdmaResourceKey(
@@ -683,7 +770,7 @@ class PeerAgent:
                 peer_alias,
                 local_key,
                 peer_key,
-                qp_num or self.qp_num,
+                qp_num or 1,
                 profile=profile,
             )
             self._connections[peer_alias] = conn
@@ -703,7 +790,7 @@ class PeerAgent:
             "profile": conn.profile,
         }
 
-    def ensure_connection_from_meta(
+    def _ensure_connection_from_meta(
         self, peer_alias: str, meta: Dict[str, Any]
     ) -> DirectedConnection:
         """Create local connection state from a peer's directed request."""
@@ -728,18 +815,18 @@ class PeerAgent:
             peer_alias,
             local_key=local_key,
             peer_key=peer_key,
-            qp_num=int(meta.get("qp_num") or self.qp_num),
+            qp_num=int(meta.get("qp_num") or 1),
             profile=str(meta.get("profile") or "default"),
         )
 
-    def ensure_local_endpoint_created(self, peer_alias: str) -> RDMAEndpoint:
+    def _ensure_local_endpoint_created(self, peer_alias: str) -> RDMAEndpoint:
         """
         Idempotent: create endpoint for peer if not exists.
         Returns the endpoint (existing or newly created). Thread-safe.
 
         The RDMAEndpoint constructor allocates QPs, which takes ~10-15 ms
         per call. We release `_endpoints_lock` during construction so that
-        concurrent pre-creation of many endpoints (see set_desired_topology)
+        concurrent pre-creation of many endpoints (see connect_to)
         actually runs in parallel — otherwise holding the lock would
         serialize the QP allocations and defeat the purpose.
         """
@@ -775,16 +862,40 @@ class PeerAgent:
             conn.attach_endpoint(new_ep, pool)
             return new_ep
 
-    def get_connected_peers(self) -> Set[str]:
-        """Return set of peer aliases we've successfully connected to."""
-        with self._connected_peers_lock:
-            return set(self._connected_peers)
+    def get_connections(self) -> Dict[str, Dict[str, PeerConnection]]:
+        """Return local connections grouped by peer and connection id."""
+        result: Dict[str, Dict[str, PeerConnection]] = {}
+        with self._connections_lock:
+            items = list(self._connections.items())
+        for peer_alias, conn in items:
+            result.setdefault(peer_alias, {})[conn.conn_id] = PeerConnection(
+                self, peer_alias
+            )
+        return result
 
-    def is_peer_connected(self, peer_alias: str) -> bool:
+    def query_connection(
+        self,
+        peer_alias: str,
+        *,
+        local_nic: Optional[str] = None,
+        remote_nic: Optional[str] = None,
+    ) -> Optional[PeerConnection]:
+        """Return a connection matching peer and optional NIC filters."""
+        with self._connections_lock:
+            conn = self._connections.get(peer_alias)
+        if conn is None:
+            return None
+        if local_nic is not None and conn.local_key.device != local_nic:
+            return None
+        if remote_nic is not None and conn.peer_key.device != remote_nic:
+            return None
+        return PeerConnection(self, peer_alias)
+
+    def _is_peer_connected(self, peer_alias: str) -> bool:
         with self._connected_peers_lock:
             return peer_alias in self._connected_peers
 
-    def mark_peer_connected(self, peer_alias: str) -> None:
+    def _mark_peer_connected(self, peer_alias: str) -> None:
         with self._connections_lock:
             conn = self._connections.get(peer_alias)
             if conn is not None:
@@ -793,18 +904,18 @@ class PeerAgent:
             self._connected_peers.add(peer_alias)
             self._connected_peers_cond.notify_all()
 
-    def has_notified_peer(self, peer_alias: str) -> bool:
+    def _has_notified_peer(self, peer_alias: str) -> bool:
         """True iff we've already sent our qp_ready to this peer during the
         current session. Suppresses the redundant outbound qp_ready that
         would otherwise fire on every qp_ready we *receive*."""
         with self._notified_peers_lock:
             return peer_alias in self._notified_peers
 
-    def mark_peer_notified(self, peer_alias: str) -> None:
+    def _mark_peer_notified(self, peer_alias: str) -> None:
         with self._notified_peers_lock:
             self._notified_peers.add(peer_alias)
 
-    def clear_peer_notified(self, peer_alias: str) -> None:
+    def _clear_peer_notified(self, peer_alias: str) -> None:
         """Allow the next handshake cycle to re-notify — called when a
         peer disconnects / is cleaned up so a reconnect works."""
         with self._notified_peers_lock:
@@ -813,51 +924,20 @@ class PeerAgent:
     # ------------------------------------------------------------------
     # Topology
     # ------------------------------------------------------------------
-    def set_desired_topology(
+    def connect_to(
         self,
-        peer_alias: Optional[str] = None,
+        peer_alias: str,
         local_device: Optional[str] = None,
         peer_device: Optional[str] = None,
         ib_port: Optional[int] = 1,
         qp_num: Optional[int] = 1,
         min_bw: Optional[str] = None,
-        target_peers: Optional[List[str]] = None,
-    ):
-        """Declare directed connection(s) and start async rendezvous.
+    ) -> PeerConnection:
+        """Start connecting to a peer and return a connection handle."""
+        if not isinstance(peer_alias, str) or not peer_alias:
+            raise TypeError("connect_to() requires a non-empty peer alias string")
 
-        New form:
-            set_desired_topology(peer_alias, local_device=None, peer_device=None,
-                                 ib_port=1, qp_num=1)
-
-        Old list/keyword form is accepted for examples and benches while they
-        migrate.
-        """
-        if target_peers is not None:
-            for p in target_peers:
-                self.set_desired_topology(
-                    p,
-                    local_device=local_device,
-                    peer_device=peer_device,
-                    ib_port=ib_port,
-                    qp_num=qp_num,
-                    min_bw=min_bw,
-                )
-            return None
-        if isinstance(peer_alias, list):
-            for p in peer_alias:
-                self.set_desired_topology(
-                    p,
-                    local_device=local_device,
-                    peer_device=peer_device,
-                    ib_port=ib_port,
-                    qp_num=qp_num,
-                    min_bw=min_bw,
-                )
-            return None
-        if peer_alias is None:
-            raise TypeError("set_desired_topology() requires peer_alias")
-
-        _tlog(f"{self.alias}: set_desired_topology({peer_alias}) ENTER")
+        _tlog(f"{self.alias}: connect_to({peer_alias}) ENTER")
         t0 = time.perf_counter()
 
         local_key = self._first_usable_resource_key(
@@ -884,13 +964,13 @@ class PeerAgent:
             peer_alias,
             local_key=local_key,
             peer_key=peer_key,
-            qp_num=qp_num or self.qp_num,
+            qp_num=qp_num or 1,
         )
 
         # Pre-create the local endpoint asynchronously. DirectedConnection is
-        # only internal state; callers use wait_for_peers() and query_endpoint().
+        # only internal state; callers use the returned PeerConnection handle.
         future = self._endpoint_creation_pool.submit(
-            self.ensure_local_endpoint_created, peer_alias
+            self._ensure_local_endpoint_created, peer_alias
         )
 
         def _mark_failed_on_error(f):
@@ -898,7 +978,9 @@ class PeerAgent:
                 f.result()
             except Exception as e:
                 conn.mark_failed()
-                print(f"PeerAgent {self.alias}: endpoint pre-create failed: {e}")
+                logger.warning(
+                    "PeerAgent %s: endpoint pre-create failed: %s", self.alias, e
+                )
 
         future.add_done_callback(_mark_failed_on_error)
 
@@ -908,44 +990,46 @@ class PeerAgent:
             min_bw=min_bw,
         )
         _tlog(
-            f"{self.alias}: set_desired_topology HTTP RTT "
+            f"{self.alias}: connect_to HTTP RTT "
             f"+{(time.perf_counter() - t0) * 1000:.3f}ms"
         )
         if result.get("status") != "ok":
-            raise RuntimeError(f"set_desired_topology failed: {result}")
+            raise RuntimeError(f"connect_to failed: {result}")
 
-        return None
+        return PeerConnection(self, peer_alias)
 
-    def query(self) -> Dict[str, Dict[str, Any]]:
-        """Query all registered peer agents."""
-        agents = self._client.query_peers()
-        return {agent["name"]: agent for agent in agents}
-
-    def wait_for_peers(self, peers: List[str], timeout_sec: float = 60.0) -> None:
-        """
-        Block until all specified peers are connected.
-        Useful for tests / sync points after set_desired_topology.
+    def _wait_connected(self, peer_alias: str, timeout_sec: float = 60.0) -> None:
+        """Block until one peer connection is ready.
 
         Event-driven: mark_peer_connected notifies the condition variable,
         so the wakeup latency is whatever threading.Condition adds on top
         of the reconciler's mark — no polling interval floor.
         """
-        _tlog(f"{self.alias}: wait_for_peers({peers}) ENTER")
+        with self._connections_lock:
+            unknown = peer_alias not in self._connections
+            known = sorted(self._connections)
+        if unknown:
+            raise ValueError(
+                f"wait() got peer with no connection: {peer_alias!r}. "
+                f"Known peers: {known}. Call connect_to(peer, ...) first; "
+                "device names belong in connect_to(), not wait()."
+            )
+
+        _tlog(f"{self.alias}: wait({peer_alias}) ENTER")
         t0 = time.perf_counter()
         deadline = time.monotonic() + timeout_sec
         with self._connected_peers_cond:
             while True:
-                missing = [p for p in peers if p not in self._connected_peers]
-                if not missing:
+                if peer_alias in self._connected_peers:
                     _tlog(
-                        f"{self.alias}: wait_for_peers({peers}) DONE "
+                        f"{self.alias}: wait({peer_alias}) DONE "
                         f"+{(time.perf_counter() - t0) * 1000:.3f}ms"
                     )
                     return
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     raise TimeoutError(
-                        f"Timeout waiting for peers {peers}. "
+                        f"Timeout waiting for peer {peer_alias!r}. "
                         f"Connected: {sorted(self._connected_peers)}"
                     )
                 self._connected_peers_cond.wait(timeout=remaining)
@@ -978,16 +1062,18 @@ class PeerAgent:
             if self._connections:
                 return next(iter(self._connections.values())).local_key
         return self._first_usable_resource_key(
-            self._local_resource, ib_port=self.ib_port, link_type=self.link_type
+            self._local_resource,
+            ib_port=1,
+            link_type=None,
         )
 
     def _publish_memory_keys(self) -> None:
-        if self.redis_client is None or not self.alias:
+        if self._redis_client is None or not self.alias:
             return
         with self._regions_lock:
             memory_keys = sorted(self._logical_regions.keys())
         try:
-            self.redis_client.hset(
+            self._redis_client.hset(
                 self._agent_key(self.alias),
                 mapping={
                     "memory_keys": json.dumps(memory_keys),
@@ -1001,7 +1087,9 @@ class PeerAgent:
                 },
             )
         except Exception as e:
-            print(f"PeerAgent {self.alias}: Memory key publish warning: {e}")
+            logger.warning(
+                "PeerAgent %s: Memory key publish warning: %s", self.alias, e
+            )
 
     def _materialize_all_regions_for_key(self, key: RdmaResourceKey) -> None:
         with self._regions_lock:
@@ -1044,19 +1132,13 @@ class PeerAgent:
             "lkey": 0,
         }
 
-        self.redis_client.set(mr_key, json.dumps(mr_data))
-        self.redis_client.set(mr_key_specific, json.dumps(mr_data))
+        self._redis_client.set(mr_key, json.dumps(mr_data))
+        self._redis_client.set(mr_key_specific, json.dumps(mr_data))
 
         materialized = MaterializedMemoryRegion(mr_name, key, handler, mr_data)
         with self._regions_lock:
             self._materialized_regions[cache_key] = materialized
         return materialized
-
-    def get_local_handle(
-        self, mr_name: str, resource_key: Optional[RdmaResourceKey] = None
-    ) -> int:
-        key = resource_key or self._default_local_resource_key()
-        return self._materialize_region(mr_name, key).handler
 
     def get_mr_info(
         self,
@@ -1085,11 +1167,11 @@ class PeerAgent:
         mr_key = f"{prefix}mr:{peer_alias}:{mr_name}"
         if resource_key is not None:
             specific_key = f"{mr_key}:{resource_key.redis_suffix()}"
-            mr_info_str = self.redis_client.get(specific_key)
+            mr_info_str = self._redis_client.get(specific_key)
             if not mr_info_str:
-                mr_info_str = self.redis_client.get(mr_key)
+                mr_info_str = self._redis_client.get(mr_key)
         else:
-            mr_info_str = self.redis_client.get(mr_key)
+            mr_info_str = self._redis_client.get(mr_key)
 
         if not mr_info_str:
             return None
@@ -1105,7 +1187,7 @@ class PeerAgent:
 
         return mr_info
 
-    def register_remote_memory_region(
+    def _register_remote_memory_region(
         self,
         peer_alias: str,
         mr_name: str,
@@ -1114,29 +1196,32 @@ class PeerAgent:
     ) -> int:
         """Register remote memory region."""
         if endpoint is None:
-            endpoint = self.query_endpoint(peer_alias)
+            endpoint = self._get_endpoint(peer_alias)
         return endpoint.register_remote_memory_region(mr_name, mr_info)
 
-    def get_remote_handle(
+    def get_handle(
         self,
-        peer_alias: str,
         mr_name: str,
+        peer_alias: Optional[str] = None,
         resource_key: Optional[RdmaResourceKey] = None,
         endpoint: Optional[RDMAEndpoint] = None,
     ) -> int:
-        """Resolve a peer's published MR name to a local remote-MR handle.
+        """Resolve local or peer MR name to a handle.
 
-        One-shot convenience for the common pattern of
-        ``get_mr_info`` + ``register_remote_memory_region``. Both underlying
-        steps are idempotent (info is cached; the remote pool returns the
-        existing handle on repeat registration), so calling this repeatedly
-        is cheap.
+        With ``peer_alias=None`` this materializes a local memory region and
+        returns its local handle. With ``peer_alias`` set, it reads the peer's
+        published MR info from Redis and registers the remote region on the
+        selected endpoint if needed.
 
         Raises:
             RuntimeError: if the peer has not published the named MR yet.
                 Callers who expect to race the publisher should poll
                 ``get_mr_info`` directly rather than catching this.
         """
+        if peer_alias is None or peer_alias == self.alias:
+            key = resource_key or self._default_local_resource_key()
+            return self._materialize_region(mr_name, key).handler
+
         mr_info = self.get_mr_info(peer_alias, mr_name, resource_key=resource_key)
         if mr_info is None:
             raise RuntimeError(
@@ -1144,7 +1229,7 @@ class PeerAgent:
                 "published yet. Ensure the peer called "
                 "register_memory_region before requesting its handle."
             )
-        return self.register_remote_memory_region(
+        return self._register_remote_memory_region(
             peer_alias, mr_name, mr_info, endpoint=endpoint
         )
 
@@ -1157,11 +1242,11 @@ class PeerAgent:
         if conn is None:
             raise RuntimeError(
                 f"Connection for {peer_alias} not found. "
-                "Call set_desired_topology(peer, ...) first."
+                "Call connect_to(peer, ...) first."
             )
         return conn
 
-    def query_endpoint(
+    def _get_endpoint(
         self,
         peer_alias: str,
         local_device: Optional[str] = None,
@@ -1199,7 +1284,7 @@ class PeerAgent:
             if endpoint is None:
                 raise RuntimeError(
                     f"Endpoint for {peer_alias} not found. "
-                    "Call set_desired_topology(peer, ...), then wait_for_peers([...])."
+                    "Call connect_to(peer, ...).wait() first."
                 )
             if conn.endpoint is None:
                 _, pool = self._get_context_and_pool(conn.local_key)
@@ -1244,10 +1329,12 @@ class PeerAgent:
                     "(region, local_offset, remote_offset, length) or "
                     "(local_region, remote_region, local_offset, remote_offset, length)"
                 )
-            local_handle = self.get_local_handle(str(local_region), conn.local_key)
-            remote_handle = self.get_remote_handle(
-                conn.peer_alias,
+            local_handle = self.get_handle(
+                str(local_region), resource_key=conn.local_key
+            )
+            remote_handle = self.get_handle(
                 str(remote_region),
+                conn.peer_alias,
                 resource_key=conn.peer_key,
                 endpoint=endpoint,
             )
@@ -1273,14 +1360,14 @@ class PeerAgent:
     # resolution; numeric assignments are passed through to the raw endpoint.
     def read(self, peer_alias: str, assign, stream=None):
         conn = self._get_connection(peer_alias)
-        endpoint = self.query_endpoint(peer_alias)
+        endpoint = self._get_endpoint(peer_alias)
         return endpoint.read(
             self._maybe_endpoint_assign(conn, endpoint, assign), stream
         )
 
     def write(self, peer_alias: str, assign, stream=None):
         conn = self._get_connection(peer_alias)
-        endpoint = self.query_endpoint(peer_alias)
+        endpoint = self._get_endpoint(peer_alias)
         return endpoint.write(
             self._maybe_endpoint_assign(conn, endpoint, assign), stream
         )
@@ -1293,19 +1380,19 @@ class PeerAgent:
         stream=None,
     ):
         conn = self._get_connection(peer_alias)
-        endpoint = self.query_endpoint(peer_alias)
+        endpoint = self._get_endpoint(peer_alias)
         return endpoint.write_with_imm(
             self._maybe_endpoint_assign(conn, endpoint, assign), imm_data, stream
         )
 
     def send(self, peer_alias: str, chunk, stream=None):
-        return self.query_endpoint(peer_alias).send(chunk, stream)
+        return self._get_endpoint(peer_alias).send(chunk, stream)
 
     def recv(self, peer_alias: str, chunk, stream=None):
-        return self.query_endpoint(peer_alias).recv(chunk, stream)
+        return self._get_endpoint(peer_alias).recv(chunk, stream)
 
     def imm_recv(self, peer_alias: str, stream=None):
-        return self.query_endpoint(peer_alias).imm_recv(stream)
+        return self._get_endpoint(peer_alias).imm_recv(stream)
 
     # ------------------------------------------------------------------
     # Shutdown
@@ -1316,7 +1403,7 @@ class PeerAgent:
             return
         self._shutdown_called = True
 
-        print(f"PeerAgent {self.alias}: Shutting down...")
+        logger.info("PeerAgent %s: Shutting down...", self.alias)
 
         self._stop_event.set()
         if self._mailbox:
@@ -1333,20 +1420,24 @@ class PeerAgent:
         try:
             self._endpoint_creation_pool.shutdown(wait=True)
         except Exception as e:
-            print(f"PeerAgent {self.alias}: endpoint-pool shutdown warning: {e}")
+            logger.warning(
+                "PeerAgent %s: endpoint-pool shutdown warning: %s", self.alias, e
+            )
 
         # Clean up exchange keys to prevent stale QP info
-        prefix = f"{self.redis_key_prefix}:" if self.redis_key_prefix else ""
-        if self.redis_client is not None:
+        prefix = f"{self._redis_key_prefix}:" if self._redis_key_prefix else ""
+        if self._redis_client is not None:
             with self._endpoints_lock:
                 for peer in list(self._endpoints.keys()):
                     exchange_key_out = f"{prefix}exchange:{self.alias}:{peer}"
                     exchange_key_in = f"{prefix}exchange:{peer}:{self.alias}"
                     try:
-                        self.redis_client.delete(exchange_key_out, exchange_key_in)
+                        self._redis_client.delete(exchange_key_out, exchange_key_in)
                     except Exception as e:
-                        print(
-                            f"PeerAgent {self.alias}: Exchange key cleanup warning: {e}"
+                        logger.warning(
+                            "PeerAgent %s: Exchange key cleanup warning: %s",
+                            self.alias,
+                            e,
                         )
                 self._endpoints.clear()
         else:
@@ -1359,36 +1450,40 @@ class PeerAgent:
             self._notified_peers.clear()
 
         # Clean up stream mailbox
-        if self.redis_client is not None:
+        if self._redis_client is not None:
             stream_key = f"{prefix}stream:{self.alias}"
             try:
-                self.redis_client.delete(stream_key)
+                self._redis_client.delete(stream_key)
             except Exception as e:
-                print(f"PeerAgent {self.alias}: Stream cleanup warning: {e}")
+                logger.warning(
+                    "PeerAgent %s: Stream cleanup warning: %s", self.alias, e
+                )
 
             # Clean up topology spec
             spec_key = f"{prefix}spec:topology:{self.alias}"
             try:
-                self.redis_client.delete(spec_key)
+                self._redis_client.delete(spec_key)
             except Exception as e:
-                print(f"PeerAgent {self.alias}: Spec cleanup warning: {e}")
+                logger.warning("PeerAgent %s: Spec cleanup warning: %s", self.alias, e)
 
             # Clean up MR keys (all memory regions registered by this agent)
             mr_pattern = f"{prefix}mr:{self.alias}:*"
             try:
-                mr_keys = list(self.redis_client.scan_iter(match=mr_pattern, count=100))
+                mr_keys = list(
+                    self._redis_client.scan_iter(match=mr_pattern, count=100)
+                )
                 if mr_keys:
-                    self.redis_client.delete(*mr_keys)
+                    self._redis_client.delete(*mr_keys)
             except Exception as e:
-                print(f"PeerAgent {self.alias}: MR cleanup warning: {e}")
+                logger.warning("PeerAgent %s: MR cleanup warning: %s", self.alias, e)
 
         try:
             self._client.cleanup_peer(self.alias)
-            print(f"PeerAgent {self.alias}: Cleanup OK")
+            logger.info("PeerAgent %s: Cleanup OK", self.alias)
         except Exception as e:
-            print(f"PeerAgent {self.alias}: Cleanup API warning: {e}")
+            logger.warning("PeerAgent %s: Cleanup API warning: %s", self.alias, e)
 
-        print(f"PeerAgent {self.alias}: Shutdown complete")
+        logger.info("PeerAgent %s: Shutdown complete", self.alias)
 
     def __enter__(self) -> "PeerAgent":
         return self
@@ -1402,42 +1497,32 @@ class PeerAgent:
             try:
                 self.shutdown()
             except Exception as e:
-                print(f"PeerAgent {self.alias}: Warning in __del__: {e}")
+                logger.warning("PeerAgent %s: Warning in __del__: %s", self.alias, e)
 
 
 def start_peer_agent(
+    nanoctrl_url: str = "http://127.0.0.1:3000",
     alias: Optional[str] = None,
-    server_url: str = "http://127.0.0.1:3000",
     device: Optional[str] = None,
-    ib_port: int = 1,
-    link_type: Optional[str] = None,
-    qp_num: int = 1,
     scope: Optional[str] = None,
 ) -> PeerAgent:
     """
     Start a peer agent (convenience function).
 
     Args:
+        nanoctrl_url: Control plane URL
         alias: (Optional) Agent name. If None, requests unique name from NanoCtrl.
-        server_url: Control plane URL
         device: RDMA device
-        ib_port: InfiniBand port
-        link_type: Optional compatibility override. Prefer topology discovery.
-        qp_num: Number of queue pairs
         scope: Scope string for multi-tenant isolation (used as Redis key prefix).
 
     Returns:
         PeerAgent instance
 
-    Use set_desired_topology(peer_alias, ...) to declare a directed connection,
-    then wait_for_peers([...]) before data-plane I/O.
+    Use connect_to(peer_alias, ...).wait() before data-plane I/O.
     """
     return PeerAgent(
+        nanoctrl_url=nanoctrl_url,
         alias=alias,
-        server_url=server_url,
         device=device,
-        ib_port=ib_port,
-        link_type=link_type,
-        qp_num=qp_num,
         scope=scope,
     )

--- a/dlslime/peer_agent/_agent.py
+++ b/dlslime/peer_agent/_agent.py
@@ -112,33 +112,38 @@ class DirectedConnection:
 class PeerConnection:
     """Public handle for one peer connection."""
 
-    def __init__(self, agent: "PeerAgent", peer_alias: str) -> None:
+    def __init__(self, agent: "PeerAgent", conn_id: str) -> None:
         self._agent = agent
-        self.peer_alias = peer_alias
+        self._conn_id = conn_id
 
     def _connection(self) -> DirectedConnection:
         with self._agent._connections_lock:
-            conn = self._agent._connections.get(self.peer_alias)
+            conn = self._agent._connections.get(self._conn_id)
         if conn is None:
             raise RuntimeError(
-                f"Connection for {self.peer_alias} not found. "
+                f"Connection {self._conn_id!r} not found. "
                 "Call connect_to(peer, ...) first."
             )
         return conn
 
+    @property
+    def peer_alias(self) -> str:
+        """Return the peer alias for this connection."""
+        return self._connection().peer_alias
+
     def wait(self, timeout: float = 60.0) -> "PeerConnection":
         """Block until this peer connection is ready."""
-        self._agent._wait_connected(self.peer_alias, timeout_sec=timeout)
+        self._agent._wait_connected(self._conn_id, timeout_sec=timeout)
         return self
 
     def is_connected(self) -> bool:
         """Return whether this peer is connected locally."""
-        return self._agent._is_peer_connected(self.peer_alias)
+        return self._agent._is_connection_connected(self._conn_id)
 
     @property
     def conn_id(self) -> str:
         """Return the stable connection id."""
-        return self._connection().conn_id
+        return self._conn_id
 
     @property
     def local_nic(self) -> str:
@@ -162,7 +167,7 @@ class PeerConnection:
         if conn.endpoint is not None:
             return conn.endpoint
         with self._agent._endpoints_lock:
-            endpoint = self._agent._endpoints.get(self.peer_alias)
+            endpoint = self._agent._endpoints.get(self._conn_id)
         if endpoint is not None:
             _, pool = self._agent._get_context_and_pool(conn.local_key)
             conn.attach_endpoint(endpoint, pool)
@@ -224,11 +229,11 @@ class PeerAgent:
         # unchanged.
         self._connected_peers_cond = threading.Condition(self._connected_peers_lock)
 
-        # Prevents duplicate in-flight connect attempts for the same peer.
+        # Prevents duplicate in-flight connect attempts for the same connection.
         self._connecting_peers: Set[str] = set()
         self._connecting_peers_lock = threading.Lock()
 
-        # Peers we've already XADDed our qp_ready to. Used to suppress
+        # Connections we've already XADDed our qp_ready for. Used to suppress
         # ping-pong: without this, an inbound qp_ready triggers another
         # outbound qp_ready, which triggers another inbound one, etc. —
         # each round walking the mailbox listener's single-threaded queue.
@@ -594,25 +599,37 @@ class PeerAgent:
                             logger.info(
                                 "PeerAgent %s: Cleanup from peer %s", self.alias, peer
                             )
+                            removed = []
                             with self._endpoints_lock:
-                                if peer in self._endpoints:
+                                with self._connections_lock:
+                                    conn_ids = [
+                                        conn_id
+                                        for conn_id, conn in self._connections.items()
+                                        if conn.peer_alias == peer
+                                    ]
+                                for conn_id in conn_ids:
+                                    if conn_id not in self._endpoints:
+                                        continue
                                     # Force-complete any blocked RDMA waits before
                                     # dropping the endpoint reference. Otherwise a
                                     # thread blocked in imm_recv()/wait() can hang
                                     # forever after the remote peer exits.
-                                    endpoint = self._endpoints[peer]
+                                    endpoint = self._endpoints[conn_id]
                                     if hasattr(endpoint, "shutdown"):
                                         endpoint.shutdown()
                                     with self._connected_peers_lock:
-                                        self._connected_peers.discard(peer)
+                                        self._connected_peers.discard(conn_id)
                                         self._connected_peers_cond.notify_all()
-                                    self._clear_peer_notified(peer)
-                                    del self._endpoints[peer]
-                                    logger.info(
-                                        "PeerAgent %s: Removed endpoint for %s",
-                                        self.alias,
-                                        peer,
-                                    )
+                                    self._clear_peer_notified(conn_id)
+                                    del self._endpoints[conn_id]
+                                    removed.append(conn_id)
+                            for conn_id in removed:
+                                logger.info(
+                                    "PeerAgent %s: Removed endpoint %s for %s",
+                                    self.alias,
+                                    conn_id,
+                                    peer,
+                                )
                 except redis.exceptions.ConnectionError:
                     time.sleep(0.1)
                 except Exception as e:
@@ -738,20 +755,20 @@ class PeerAgent:
         profile: str = "default",
     ) -> DirectedConnection:
         with self._connections_lock:
-            existing = self._connections.get(peer_alias)
-            if existing is not None:
-                if local_key is not None and (
-                    existing.local_key != local_key
-                    or (peer_key is not None and existing.peer_key != peer_key)
-                    or (qp_num is not None and existing.qp_num != qp_num)
-                ):
+            peer_connections = [
+                conn
+                for conn in self._connections.values()
+                if conn.peer_alias == peer_alias
+            ]
+            if local_key is None:
+                if len(peer_connections) == 1:
+                    return peer_connections[0]
+                if len(peer_connections) > 1:
                     raise RuntimeError(
-                        f"Multiple directed connections to {peer_alias} are not "
-                        "supported by the first PeerAgent implementation. "
-                        "Use get_connections() to inspect established "
-                        "connections."
+                        f"Multiple connections to {peer_alias} exist. "
+                        "Use query_connection(peer, local_nic=..., remote_nic=...) "
+                        "to select one."
                     )
-                return existing
 
             if local_key is None:
                 local_key = self._first_usable_resource_key(
@@ -765,6 +782,14 @@ class PeerAgent:
                     local_key.ib_port,
                     local_key.link_type,
                 )
+            for conn in peer_connections:
+                if conn.local_key == local_key and conn.peer_key == peer_key:
+                    if qp_num is not None and conn.qp_num != qp_num:
+                        raise RuntimeError(
+                            f"Connection {conn.conn_id} already exists with "
+                            f"qp_num={conn.qp_num}, not {qp_num}."
+                        )
+                    return conn
             conn = DirectedConnection(
                 self,
                 peer_alias,
@@ -773,15 +798,16 @@ class PeerAgent:
                 qp_num or 1,
                 profile=profile,
             )
-            self._connections[peer_alias] = conn
+            self._connections[conn.conn_id] = conn
             return conn
 
-    def _connection_meta(self, peer_alias: str) -> Dict[str, Any]:
-        conn = self._get_or_create_connection(peer_alias)
+    def _connection_meta(self, conn_id: str) -> Dict[str, Any]:
+        with self._connections_lock:
+            conn = self._connections[conn_id]
         return {
             "conn_id": conn.conn_id,
             "src": self.alias,
-            "dst": peer_alias,
+            "dst": conn.peer_alias,
             "src_device": conn.local_key.device,
             "dst_device": conn.peer_key.device,
             "ib_port": conn.local_key.ib_port,
@@ -819,7 +845,7 @@ class PeerAgent:
             profile=str(meta.get("profile") or "default"),
         )
 
-    def _ensure_local_endpoint_created(self, peer_alias: str) -> RDMAEndpoint:
+    def _ensure_local_endpoint_created(self, conn_id: str) -> RDMAEndpoint:
         """
         Idempotent: create endpoint for peer if not exists.
         Returns the endpoint (existing or newly created). Thread-safe.
@@ -832,15 +858,17 @@ class PeerAgent:
         """
         # Fast path: lookup under lock.
         with self._endpoints_lock:
-            ep = self._endpoints.get(peer_alias)
+            ep = self._endpoints.get(conn_id)
             if ep is not None:
-                conn = self._get_or_create_connection(peer_alias)
+                with self._connections_lock:
+                    conn = self._connections[conn_id]
                 if conn.endpoint is None:
                     _, pool = self._get_context_and_pool(conn.local_key)
                     conn.attach_endpoint(ep, pool)
                 return ep
 
-        conn = self._get_or_create_connection(peer_alias)
+        with self._connections_lock:
+            conn = self._connections[conn_id]
         _, pool = self._get_context_and_pool(conn.local_key)
         self._materialize_all_regions_for_key(conn.local_key)
 
@@ -852,13 +880,13 @@ class PeerAgent:
         )
 
         with self._endpoints_lock:
-            existing = self._endpoints.get(peer_alias)
+            existing = self._endpoints.get(conn_id)
             if existing is not None:
                 # Lost the race. `new_ep` goes out of scope; its destructor
                 # releases the QPs we allocated. Cheap in absolute terms
                 # (~14 ms once) and rare in practice.
                 return existing
-            self._endpoints[peer_alias] = new_ep
+            self._endpoints[conn_id] = new_ep
             conn.attach_endpoint(new_ep, pool)
             return new_ep
 
@@ -867,9 +895,9 @@ class PeerAgent:
         result: Dict[str, Dict[str, PeerConnection]] = {}
         with self._connections_lock:
             items = list(self._connections.items())
-        for peer_alias, conn in items:
-            result.setdefault(peer_alias, {})[conn.conn_id] = PeerConnection(
-                self, peer_alias
+        for conn_id, conn in items:
+            result.setdefault(conn.peer_alias, {})[conn_id] = PeerConnection(
+                self, conn_id
             )
         return result
 
@@ -881,45 +909,47 @@ class PeerAgent:
         remote_nic: Optional[str] = None,
     ) -> Optional[PeerConnection]:
         """Return a connection matching peer and optional NIC filters."""
+        matches = []
         with self._connections_lock:
-            conn = self._connections.get(peer_alias)
-        if conn is None:
+            for conn_id, conn in sorted(self._connections.items()):
+                if conn.peer_alias != peer_alias:
+                    continue
+                if local_nic is not None and conn.local_key.device != local_nic:
+                    continue
+                if remote_nic is not None and conn.peer_key.device != remote_nic:
+                    continue
+                matches.append(conn_id)
+        if not matches:
             return None
-        if local_nic is not None and conn.local_key.device != local_nic:
-            return None
-        if remote_nic is not None and conn.peer_key.device != remote_nic:
-            return None
-        return PeerConnection(self, peer_alias)
+        return PeerConnection(self, matches[0])
 
-    def _is_peer_connected(self, peer_alias: str) -> bool:
+    def _is_connection_connected(self, conn_id: str) -> bool:
         with self._connected_peers_lock:
-            return peer_alias in self._connected_peers
+            return conn_id in self._connected_peers
 
-    def _mark_peer_connected(self, peer_alias: str) -> None:
+    def _mark_connection_connected(self, conn_id: str) -> None:
         with self._connections_lock:
-            conn = self._connections.get(peer_alias)
+            conn = self._connections.get(conn_id)
             if conn is not None:
                 conn.mark_connected()
         with self._connected_peers_lock:
-            self._connected_peers.add(peer_alias)
+            self._connected_peers.add(conn_id)
             self._connected_peers_cond.notify_all()
 
-    def _has_notified_peer(self, peer_alias: str) -> bool:
-        """True iff we've already sent our qp_ready to this peer during the
-        current session. Suppresses the redundant outbound qp_ready that
-        would otherwise fire on every qp_ready we *receive*."""
+    def _has_notified_peer(self, conn_id: str) -> bool:
+        """True iff we've already sent qp_ready for this connection."""
         with self._notified_peers_lock:
-            return peer_alias in self._notified_peers
+            return conn_id in self._notified_peers
 
-    def _mark_peer_notified(self, peer_alias: str) -> None:
+    def _mark_peer_notified(self, conn_id: str) -> None:
         with self._notified_peers_lock:
-            self._notified_peers.add(peer_alias)
+            self._notified_peers.add(conn_id)
 
-    def _clear_peer_notified(self, peer_alias: str) -> None:
+    def _clear_peer_notified(self, conn_id: str) -> None:
         """Allow the next handshake cycle to re-notify — called when a
         peer disconnects / is cleaned up so a reconnect works."""
         with self._notified_peers_lock:
-            self._notified_peers.discard(peer_alias)
+            self._notified_peers.discard(conn_id)
 
     # ------------------------------------------------------------------
     # Topology
@@ -970,7 +1000,7 @@ class PeerAgent:
         # Pre-create the local endpoint asynchronously. DirectedConnection is
         # only internal state; callers use the returned PeerConnection handle.
         future = self._endpoint_creation_pool.submit(
-            self._ensure_local_endpoint_created, peer_alias
+            self._ensure_local_endpoint_created, conn.conn_id
         )
 
         def _mark_failed_on_error(f):
@@ -996,9 +1026,9 @@ class PeerAgent:
         if result.get("status") != "ok":
             raise RuntimeError(f"connect_to failed: {result}")
 
-        return PeerConnection(self, peer_alias)
+        return PeerConnection(self, conn.conn_id)
 
-    def _wait_connected(self, peer_alias: str, timeout_sec: float = 60.0) -> None:
+    def _wait_connected(self, conn_id: str, timeout_sec: float = 60.0) -> None:
         """Block until one peer connection is ready.
 
         Event-driven: mark_peer_connected notifies the condition variable,
@@ -1006,31 +1036,31 @@ class PeerAgent:
         of the reconciler's mark — no polling interval floor.
         """
         with self._connections_lock:
-            unknown = peer_alias not in self._connections
+            unknown = conn_id not in self._connections
             known = sorted(self._connections)
         if unknown:
             raise ValueError(
-                f"wait() got peer with no connection: {peer_alias!r}. "
-                f"Known peers: {known}. Call connect_to(peer, ...) first; "
+                f"wait() got unknown connection: {conn_id!r}. "
+                f"Known connections: {known}. Call connect_to(peer, ...) first; "
                 "device names belong in connect_to(), not wait()."
             )
 
-        _tlog(f"{self.alias}: wait({peer_alias}) ENTER")
+        _tlog(f"{self.alias}: wait({conn_id}) ENTER")
         t0 = time.perf_counter()
         deadline = time.monotonic() + timeout_sec
         with self._connected_peers_cond:
             while True:
-                if peer_alias in self._connected_peers:
+                if conn_id in self._connected_peers:
                     _tlog(
-                        f"{self.alias}: wait({peer_alias}) DONE "
+                        f"{self.alias}: wait({conn_id}) DONE "
                         f"+{(time.perf_counter() - t0) * 1000:.3f}ms"
                     )
                     return
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     raise TimeoutError(
-                        f"Timeout waiting for peer {peer_alias!r}. "
-                        f"Connected: {sorted(self._connected_peers)}"
+                        f"Timeout waiting for connection {conn_id!r}. "
+                        f"Connected connections: {sorted(self._connected_peers)}"
                     )
                 self._connected_peers_cond.wait(timeout=remaining)
 
@@ -1236,15 +1266,34 @@ class PeerAgent:
     # ------------------------------------------------------------------
     # I/O
     # ------------------------------------------------------------------
-    def _get_connection(self, peer_alias: str) -> DirectedConnection:
+    def _get_connection(
+        self,
+        peer_alias: str,
+        local_device: Optional[str] = None,
+        peer_device: Optional[str] = None,
+        ib_port: Optional[int] = None,
+        qp_num: Optional[int] = None,
+    ) -> DirectedConnection:
+        matches = []
         with self._connections_lock:
-            conn = self._connections.get(peer_alias)
-        if conn is None:
+            for _, conn in sorted(self._connections.items()):
+                if conn.peer_alias != peer_alias:
+                    continue
+                if local_device is not None and conn.local_key.device != local_device:
+                    continue
+                if peer_device is not None and conn.peer_key.device != peer_device:
+                    continue
+                if ib_port is not None and conn.local_key.ib_port != int(ib_port):
+                    continue
+                if qp_num is not None and conn.qp_num != int(qp_num):
+                    continue
+                matches.append(conn)
+        if not matches:
             raise RuntimeError(
                 f"Connection for {peer_alias} not found. "
                 "Call connect_to(peer, ...) first."
             )
-        return conn
+        return matches[0]
 
     def _get_endpoint(
         self,
@@ -1255,7 +1304,13 @@ class PeerAgent:
         qp_num: Optional[int] = None,
     ) -> RDMAEndpoint:
         """Return the established RDMAEndpoint selected by a directed topology."""
-        conn = self._get_connection(peer_alias)
+        conn = self._get_connection(
+            peer_alias,
+            local_device=local_device,
+            peer_device=peer_device,
+            ib_port=ib_port,
+            qp_num=qp_num,
+        )
         if local_device is not None and conn.local_key.device != local_device:
             raise RuntimeError(
                 f"Endpoint for {peer_alias} uses local device "
@@ -1280,7 +1335,7 @@ class PeerAgent:
             return conn.endpoint
 
         with self._endpoints_lock:
-            endpoint = self._endpoints.get(peer_alias)
+            endpoint = self._endpoints.get(conn.conn_id)
             if endpoint is None:
                 raise RuntimeError(
                     f"Endpoint for {peer_alias} not found. "
@@ -1358,16 +1413,40 @@ class PeerAgent:
 
     # One-shot I/O forwarders. Named batches use PeerAgent memory-key
     # resolution; numeric assignments are passed through to the raw endpoint.
-    def read(self, peer_alias: str, assign, stream=None):
-        conn = self._get_connection(peer_alias)
-        endpoint = self._get_endpoint(peer_alias)
+    def read(
+        self,
+        peer_alias: str,
+        assign,
+        stream=None,
+        *,
+        local_nic: Optional[str] = None,
+        remote_nic: Optional[str] = None,
+    ):
+        conn = self._get_connection(
+            peer_alias, local_device=local_nic, peer_device=remote_nic
+        )
+        endpoint = self._get_endpoint(
+            peer_alias, local_device=local_nic, peer_device=remote_nic
+        )
         return endpoint.read(
             self._maybe_endpoint_assign(conn, endpoint, assign), stream
         )
 
-    def write(self, peer_alias: str, assign, stream=None):
-        conn = self._get_connection(peer_alias)
-        endpoint = self._get_endpoint(peer_alias)
+    def write(
+        self,
+        peer_alias: str,
+        assign,
+        stream=None,
+        *,
+        local_nic: Optional[str] = None,
+        remote_nic: Optional[str] = None,
+    ):
+        conn = self._get_connection(
+            peer_alias, local_device=local_nic, peer_device=remote_nic
+        )
+        endpoint = self._get_endpoint(
+            peer_alias, local_device=local_nic, peer_device=remote_nic
+        )
         return endpoint.write(
             self._maybe_endpoint_assign(conn, endpoint, assign), stream
         )
@@ -1378,21 +1457,57 @@ class PeerAgent:
         assign,
         imm_data: int = 0,
         stream=None,
+        *,
+        local_nic: Optional[str] = None,
+        remote_nic: Optional[str] = None,
     ):
-        conn = self._get_connection(peer_alias)
-        endpoint = self._get_endpoint(peer_alias)
+        conn = self._get_connection(
+            peer_alias, local_device=local_nic, peer_device=remote_nic
+        )
+        endpoint = self._get_endpoint(
+            peer_alias, local_device=local_nic, peer_device=remote_nic
+        )
         return endpoint.write_with_imm(
             self._maybe_endpoint_assign(conn, endpoint, assign), imm_data, stream
         )
 
-    def send(self, peer_alias: str, chunk, stream=None):
-        return self._get_endpoint(peer_alias).send(chunk, stream)
+    def send(
+        self,
+        peer_alias: str,
+        chunk,
+        stream=None,
+        *,
+        local_nic: Optional[str] = None,
+        remote_nic: Optional[str] = None,
+    ):
+        return self._get_endpoint(
+            peer_alias, local_device=local_nic, peer_device=remote_nic
+        ).send(chunk, stream)
 
-    def recv(self, peer_alias: str, chunk, stream=None):
-        return self._get_endpoint(peer_alias).recv(chunk, stream)
+    def recv(
+        self,
+        peer_alias: str,
+        chunk,
+        stream=None,
+        *,
+        local_nic: Optional[str] = None,
+        remote_nic: Optional[str] = None,
+    ):
+        return self._get_endpoint(
+            peer_alias, local_device=local_nic, peer_device=remote_nic
+        ).recv(chunk, stream)
 
-    def imm_recv(self, peer_alias: str, stream=None):
-        return self._get_endpoint(peer_alias).imm_recv(stream)
+    def imm_recv(
+        self,
+        peer_alias: str,
+        stream=None,
+        *,
+        local_nic: Optional[str] = None,
+        remote_nic: Optional[str] = None,
+    ):
+        return self._get_endpoint(
+            peer_alias, local_device=local_nic, peer_device=remote_nic
+        ).imm_recv(stream)
 
     # ------------------------------------------------------------------
     # Shutdown
@@ -1428,11 +1543,22 @@ class PeerAgent:
         prefix = f"{self._redis_key_prefix}:" if self._redis_key_prefix else ""
         if self._redis_client is not None:
             with self._endpoints_lock:
-                for peer in list(self._endpoints.keys()):
+                with self._connections_lock:
+                    endpoint_peers = {
+                        conn_id: self._connections[conn_id].peer_alias
+                        for conn_id in self._endpoints
+                        if conn_id in self._connections
+                    }
+                for conn_id, peer in endpoint_peers.items():
                     exchange_key_out = f"{prefix}exchange:{self.alias}:{peer}"
                     exchange_key_in = f"{prefix}exchange:{peer}:{self.alias}"
+                    exchange_key_out_conn = (
+                        f"{prefix}exchange:{self.alias}:{peer}:{conn_id}"
+                    )
                     try:
-                        self._redis_client.delete(exchange_key_out, exchange_key_in)
+                        self._redis_client.delete(
+                            exchange_key_out, exchange_key_in, exchange_key_out_conn
+                        )
                     except Exception as e:
                         logger.warning(
                             "PeerAgent %s: Exchange key cleanup warning: %s",

--- a/dlslime/peer_agent/_mailbox.py
+++ b/dlslime/peer_agent/_mailbox.py
@@ -225,28 +225,41 @@ class StreamMailbox:
         Attempt symmetric rendezvous with peer.
         Idempotent: safe to call multiple times.
         """
-        # Skip if already connected or a connection attempt is in progress.
-        if self._agent._is_peer_connected(peer):
-            return
-        with self._agent._connecting_peers_lock:
-            if peer in self._agent._connecting_peers:
-                return
-            self._agent._connecting_peers.add(peer)
+        if conn_meta:
+            conn = self._agent._ensure_connection_from_meta(peer, conn_meta)
+            connections = [conn]
+        else:
+            with self._agent._connections_lock:
+                connections = [
+                    conn
+                    for conn in self._agent._connections.values()
+                    if conn.peer_alias == peer
+                ]
+            if not connections:
+                connections = [self._agent._get_or_create_connection(peer)]
 
-        try:
-            self._try_connect_peer_inner(peer, peer_qp_info, conn_meta or {})
-        finally:
-            # Always release the in-flight guard. A rendezvous attempt may return
-            # early when the peer has not published its QP info yet; later
-            # connect_peer / qp_ready messages must be allowed to retry.
+        for conn in connections:
+            conn_id = conn.conn_id
+            if self._agent._is_connection_connected(conn_id):
+                continue
             with self._agent._connecting_peers_lock:
-                self._agent._connecting_peers.discard(peer)
+                if conn_id in self._agent._connecting_peers:
+                    continue
+                self._agent._connecting_peers.add(conn_id)
+
+            try:
+                self._try_connect_peer_inner(conn, peer_qp_info)
+            finally:
+                # Always release the in-flight guard. A rendezvous attempt may
+                # return early when the peer has not published its QP info yet;
+                # later connect_peer / qp_ready messages must be allowed to retry.
+                with self._agent._connecting_peers_lock:
+                    self._agent._connecting_peers.discard(conn_id)
 
     def _try_connect_peer_inner(
         self,
-        peer: str,
+        conn,
         peer_qp_info: Optional[Dict[str, Any]] = None,
-        conn_meta: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Core rendezvous logic (called with connecting-guard held).
 
@@ -258,19 +271,18 @@ class StreamMailbox:
         protocol. Keeps this version interoperable with older peers that
         don't embed QP info in their stream messages.
         """
+        peer = conn.peer_alias
+        conn_id = conn.conn_id
         t_enter = time.perf_counter()
         _tlog(
-            f"{self._agent.alias}: _try_connect_peer_inner({peer}) "
+            f"{self._agent.alias}: _try_connect_peer_inner({conn_id}) "
             f"has_qp_info={peer_qp_info is not None}"
         )
 
-        if conn_meta:
-            self._agent._ensure_connection_from_meta(peer, conn_meta)
-
         # A. Create local endpoint and get QP info
-        endpoint = self._agent._ensure_local_endpoint_created(peer)
+        endpoint = self._agent._ensure_local_endpoint_created(conn_id)
         my_qp_info = endpoint.endpoint_info()
-        my_conn_meta = self._agent._connection_meta(peer)
+        my_conn_meta = self._agent._connection_meta(conn_id)
         _tlog(
             f"{self._agent.alias}: [A] ensure_endpoint+endpoint_info "
             f"+{(time.perf_counter() - t_enter) * 1000:.3f}ms"
@@ -285,7 +297,7 @@ class StreamMailbox:
         # of the handshake with zero Redis GETs. The _has_notified_peer
         # guard prevents a qp_ready → qp_ready → qp_ready ping-pong when
         # both sides are racing through this method.
-        if not self._agent._has_notified_peer(peer):
+        if not self._agent._has_notified_peer(conn_id):
             t_b = time.perf_counter()
             peer_stream_key = f"{prefix}stream:{peer}"
             try:
@@ -301,7 +313,7 @@ class StreamMailbox:
                     maxlen=1000,
                     approximate=True,
                 )
-                self._agent._mark_peer_notified(peer)
+                self._agent._mark_peer_notified(conn_id)
             except Exception as e:
                 logger.warning(
                     "StreamMailbox %s: Failed to notify %s: %s",
@@ -314,14 +326,14 @@ class StreamMailbox:
                 f"+{(time.perf_counter() - t_b) * 1000:.3f}ms"
             )
         else:
-            _tlog(f"{self._agent.alias}: [B] skip XADD (already notified {peer})")
+            _tlog(f"{self._agent.alias}: [B] skip XADD (already notified {conn_id})")
 
         # C. Resolve peer's QP info. Fast path: we already have it from the
         # incoming qp_ready message. Interop path: fall back to the Redis
         # exchange-key protocol for older peers.
         if peer_qp_info is None:
             t_c = time.perf_counter()
-            exchange_key_out = f"{prefix}exchange:{self._agent.alias}:{peer}"
+            exchange_key_out = f"{prefix}exchange:{self._agent.alias}:{peer}:{conn_id}"
             self._agent._redis_client.set(
                 exchange_key_out,
                 json.dumps(my_qp_info, default=str),
@@ -336,7 +348,7 @@ class StreamMailbox:
             if peer_qp_info_str is None:
                 # Peer hasn't published yet; their qp_ready will trigger us.
                 _tlog(
-                    f"{self._agent.alias}: _try_connect_peer_inner({peer}) "
+                    f"{self._agent.alias}: _try_connect_peer_inner({conn_id}) "
                     f"RETURN (peer not published yet) "
                     f"total={(time.perf_counter() - t_enter) * 1000:.3f}ms"
                 )
@@ -358,9 +370,9 @@ class StreamMailbox:
             f"{self._agent.alias}: [D] endpoint.connect({peer}) "
             f"+{(time.perf_counter() - t_d) * 1000:.3f}ms"
         )
-        self._agent._mark_peer_connected(peer)
+        self._agent._mark_connection_connected(conn_id)
         _tlog(
-            f"{self._agent.alias}: [E] _mark_peer_connected({peer}) DONE "
+            f"{self._agent.alias}: [E] _mark_connection_connected({conn_id}) DONE "
             f"total={(time.perf_counter() - t_enter) * 1000:.3f}ms"
         )
         logger.info("Link Established: initiator=%s target=%s", self._agent.alias, peer)

--- a/dlslime/peer_agent/_mailbox.py
+++ b/dlslime/peer_agent/_mailbox.py
@@ -15,7 +15,7 @@ Wire protocol (stream:{agent_alias}):
 The listener runs on a single background thread. Heavy work
 (`RDMAEndpoint(...)` allocation, QP state transitions) happens inline
 on that thread, so per-message cost directly affects the scale-out tail.
-``PeerAgent`` pre-creates endpoints eagerly from ``set_desired_topology``
+``PeerAgent`` pre-creates endpoints eagerly from ``connect_to``
 to keep the listener fast path a dict lookup.
 """
 
@@ -28,7 +28,10 @@ from typing import Any, Dict, Optional, TYPE_CHECKING
 
 import redis
 
+from dlslime.logging import get_logger
 from ._obs import _tlog
+
+logger = get_logger("peer_agent.mailbox")
 
 if TYPE_CHECKING:
     from ._agent import PeerAgent
@@ -55,16 +58,17 @@ class StreamMailbox:
         """Start the stream listener thread."""
         # Delete any stale stream messages from a previous run before listening.
         prefix = (
-            f"{self._agent.redis_key_prefix}:" if self._agent.redis_key_prefix else ""
+            f"{self._agent._redis_key_prefix}:" if self._agent._redis_key_prefix else ""
         )
         stream_key = f"{prefix}stream:{self._agent.alias}"
-        self._agent.redis_client.delete(stream_key)
+        self._agent._redis_client.delete(stream_key)
 
         self._thread = threading.Thread(target=self._listen_loop, daemon=True)
         self._thread.start()
-        print(
-            f"StreamMailbox {self._agent.alias}: Started listening to stream "
-            f"(block={self._stream_block_ms}ms)"
+        logger.info(
+            "StreamMailbox %s: Started listening to stream (block=%sms)",
+            self._agent.alias,
+            self._stream_block_ms,
         )
 
     def stop(self) -> None:
@@ -72,26 +76,28 @@ class StreamMailbox:
         self._stop_event.set()
         if self._thread:
             self._thread.join(timeout=2)
-        print(f"StreamMailbox {self._agent.alias}: Stopped")
+        logger.info("StreamMailbox %s: Stopped", self._agent.alias)
 
     def _listen_loop(self) -> None:
         """Main event loop: blocking XREAD on agent's stream mailbox."""
         prefix = (
-            f"{self._agent.redis_key_prefix}:" if self._agent.redis_key_prefix else ""
+            f"{self._agent._redis_key_prefix}:" if self._agent._redis_key_prefix else ""
         )
         stream_key = f"{prefix}stream:{self._agent.alias}"
 
         # Start from the beginning of the (now-freshly-cleared) stream.
         last_id = "0-0"
 
-        print(
-            f"StreamMailbox {self._agent.alias}: Listening to {stream_key} (from beginning)"
+        logger.info(
+            "StreamMailbox %s: Listening to %s (from beginning)",
+            self._agent.alias,
+            stream_key,
         )
 
         while not self._stop_event.is_set():
             try:
                 # XREAD with blocking
-                result = self._agent.redis_client.xread(
+                result = self._agent._redis_client.xread(
                     {stream_key: last_id},
                     block=self._stream_block_ms,
                     count=100,  # Batch up to 100 messages
@@ -115,21 +121,21 @@ class StreamMailbox:
                         try:
                             self._handle_message(fields)
                         except Exception as e:
-                            print(
-                                f"StreamMailbox {self._agent.alias}: Error handling message: {e}"
+                            logger.exception(
+                                "StreamMailbox %s: Error handling message: %s",
+                                self._agent.alias,
+                                e,
                             )
-                            import traceback
-
-                            traceback.print_exc()
                         last_id = msg_id
 
             except redis.exceptions.ConnectionError:
                 time.sleep(0.1)
             except Exception as e:
-                print(f"StreamMailbox {self._agent.alias}: Error in listen loop: {e}")
-                import traceback
-
-                traceback.print_exc()
+                logger.exception(
+                    "StreamMailbox %s: Error in listen loop: %s",
+                    self._agent.alias,
+                    e,
+                )
                 time.sleep(0.1)
 
     def _handle_message(self, fields: Dict[str, str]) -> None:
@@ -144,13 +150,16 @@ class StreamMailbox:
             # to complete the handshake.
             peer = fields.get("peer")
             if peer:
-                print(
-                    f"StreamMailbox {self._agent.alias}: Received connect_peer -> {peer}"
+                logger.info(
+                    "StreamMailbox %s: Received connect_peer -> %s",
+                    self._agent.alias,
+                    peer,
                 )
                 self._try_connect_peer(peer)
             else:
-                print(
-                    f"StreamMailbox {self._agent.alias}: connect_peer missing 'peer' field"
+                logger.warning(
+                    "StreamMailbox %s: connect_peer missing 'peer' field",
+                    self._agent.alias,
                 )
 
         elif msg_type == "qp_ready":
@@ -167,34 +176,43 @@ class StreamMailbox:
                     try:
                         peer_qp_info = json.loads(qp_info_str)
                     except json.JSONDecodeError:
-                        print(
-                            f"StreamMailbox {self._agent.alias}: "
-                            f"malformed qp_info from {peer}, falling back to GET"
+                        logger.warning(
+                            "StreamMailbox %s: malformed qp_info from %s, "
+                            "falling back to GET",
+                            self._agent.alias,
+                            peer,
                         )
                 meta_str = fields.get("conn_meta")
                 if meta_str:
                     try:
                         conn_meta = json.loads(meta_str)
                     except json.JSONDecodeError:
-                        print(
-                            f"StreamMailbox {self._agent.alias}: "
-                            f"malformed conn_meta from {peer}, using defaults"
+                        logger.warning(
+                            "StreamMailbox %s: malformed conn_meta from %s, "
+                            "using defaults",
+                            self._agent.alias,
+                            peer,
                         )
-                print(
-                    f"StreamMailbox {self._agent.alias}: Received qp_ready from {peer}"
-                    f"{' (with embedded qp_info)' if peer_qp_info else ''}"
+                logger.info(
+                    "StreamMailbox %s: Received qp_ready from %s%s",
+                    self._agent.alias,
+                    peer,
+                    " (with embedded qp_info)" if peer_qp_info else "",
                 )
                 self._try_connect_peer(
                     peer, peer_qp_info=peer_qp_info, conn_meta=conn_meta
                 )
             else:
-                print(
-                    f"StreamMailbox {self._agent.alias}: qp_ready missing 'peer' field"
+                logger.warning(
+                    "StreamMailbox %s: qp_ready missing 'peer' field",
+                    self._agent.alias,
                 )
 
         else:
-            print(
-                f"StreamMailbox {self._agent.alias}: Unknown message type: {msg_type}"
+            logger.warning(
+                "StreamMailbox %s: Unknown message type: %s",
+                self._agent.alias,
+                msg_type,
             )
 
     def _try_connect_peer(
@@ -208,7 +226,7 @@ class StreamMailbox:
         Idempotent: safe to call multiple times.
         """
         # Skip if already connected or a connection attempt is in progress.
-        if self._agent.is_peer_connected(peer):
+        if self._agent._is_peer_connected(peer):
             return
         with self._agent._connecting_peers_lock:
             if peer in self._agent._connecting_peers:
@@ -247,10 +265,10 @@ class StreamMailbox:
         )
 
         if conn_meta:
-            self._agent.ensure_connection_from_meta(peer, conn_meta)
+            self._agent._ensure_connection_from_meta(peer, conn_meta)
 
         # A. Create local endpoint and get QP info
-        endpoint = self._agent.ensure_local_endpoint_created(peer)
+        endpoint = self._agent._ensure_local_endpoint_created(peer)
         my_qp_info = endpoint.endpoint_info()
         my_conn_meta = self._agent._connection_meta(peer)
         _tlog(
@@ -259,19 +277,19 @@ class StreamMailbox:
         )
 
         prefix = (
-            f"{self._agent.redis_key_prefix}:" if self._agent.redis_key_prefix else ""
+            f"{self._agent._redis_key_prefix}:" if self._agent._redis_key_prefix else ""
         )
 
         # B. Notify the peer that our QP info is ready — once. Carrying the
         # QP info in the message itself lets the peer complete their half
-        # of the handshake with zero Redis GETs. The has_notified_peer
+        # of the handshake with zero Redis GETs. The _has_notified_peer
         # guard prevents a qp_ready → qp_ready → qp_ready ping-pong when
         # both sides are racing through this method.
-        if not self._agent.has_notified_peer(peer):
+        if not self._agent._has_notified_peer(peer):
             t_b = time.perf_counter()
             peer_stream_key = f"{prefix}stream:{peer}"
             try:
-                self._agent.redis_client.xadd(
+                self._agent._redis_client.xadd(
                     peer_stream_key,
                     {
                         "type": "qp_ready",
@@ -283,10 +301,13 @@ class StreamMailbox:
                     maxlen=1000,
                     approximate=True,
                 )
-                self._agent.mark_peer_notified(peer)
+                self._agent._mark_peer_notified(peer)
             except Exception as e:
-                print(
-                    f"StreamMailbox {self._agent.alias}: Failed to notify {peer}: {e}"
+                logger.warning(
+                    "StreamMailbox %s: Failed to notify %s: %s",
+                    self._agent.alias,
+                    peer,
+                    e,
                 )
             _tlog(
                 f"{self._agent.alias}: [B] XADD qp_ready->{peer} "
@@ -301,12 +322,12 @@ class StreamMailbox:
         if peer_qp_info is None:
             t_c = time.perf_counter()
             exchange_key_out = f"{prefix}exchange:{self._agent.alias}:{peer}"
-            self._agent.redis_client.set(
+            self._agent._redis_client.set(
                 exchange_key_out,
                 json.dumps(my_qp_info, default=str),
             )
             exchange_key_in = f"{prefix}exchange:{peer}:{self._agent.alias}"
-            peer_qp_info_str = self._agent.redis_client.get(exchange_key_in)
+            peer_qp_info_str = self._agent._redis_client.get(exchange_key_in)
             _tlog(
                 f"{self._agent.alias}: [C-interop] SET+GET exchange "
                 f"+{(time.perf_counter() - t_c) * 1000:.3f}ms "
@@ -323,9 +344,10 @@ class StreamMailbox:
             try:
                 peer_qp_info = json.loads(peer_qp_info_str)
             except json.JSONDecodeError:
-                print(
-                    f"StreamMailbox {self._agent.alias}: "
-                    f"Failed to parse exchange-key QP info from {peer}"
+                logger.warning(
+                    "StreamMailbox %s: Failed to parse exchange-key QP info from %s",
+                    self._agent.alias,
+                    peer,
                 )
                 return
 
@@ -336,9 +358,9 @@ class StreamMailbox:
             f"{self._agent.alias}: [D] endpoint.connect({peer}) "
             f"+{(time.perf_counter() - t_d) * 1000:.3f}ms"
         )
-        self._agent.mark_peer_connected(peer)
+        self._agent._mark_peer_connected(peer)
         _tlog(
-            f"{self._agent.alias}: [E] mark_peer_connected({peer}) DONE "
+            f"{self._agent.alias}: [E] _mark_peer_connected({peer}) DONE "
             f"total={(time.perf_counter() - t_enter) * 1000:.3f}ms"
         )
-        print(f"Link Established: initiator={self._agent.alias} target={peer}")
+        logger.info("Link Established: initiator=%s target=%s", self._agent.alias, peer)

--- a/dlslime/rpc/proxy.py
+++ b/dlslime/rpc/proxy.py
@@ -68,14 +68,9 @@ def _get_or_create_channel(agent, peer_alias: str) -> Channel:
         if key in _channel_cache:
             return _channel_cache[key]
 
-    peer_connections = agent.get_connections().get(peer_alias, {})
-    if len(peer_connections) != 1:
-        raise ValueError(
-            f"RPC channel for peer {peer_alias!r} requires exactly 1 connection, "
-            f"got {len(peer_connections)}. Established connections: "
-            f"{list(peer_connections.keys())}"
-        )
-    connection = next(iter(peer_connections.values()))
+    connection = agent.query_connection(peer_alias)
+    if connection is None:
+        raise ValueError(f"RPC channel for peer {peer_alias!r} has no connection.")
     endpoint = connection.endpoint
     if endpoint is None or not connection.is_connected():
         raise ValueError(

--- a/dlslime/rpc/proxy.py
+++ b/dlslime/rpc/proxy.py
@@ -68,7 +68,20 @@ def _get_or_create_channel(agent, peer_alias: str) -> Channel:
         if key in _channel_cache:
             return _channel_cache[key]
 
-    endpoint = agent.query_endpoint(peer_alias)
+    peer_connections = agent.get_connections().get(peer_alias, {})
+    if len(peer_connections) != 1:
+        raise ValueError(
+            f"RPC channel for peer {peer_alias!r} requires exactly 1 connection, "
+            f"got {len(peer_connections)}. Established connections: "
+            f"{list(peer_connections.keys())}"
+        )
+    connection = next(iter(peer_connections.values()))
+    endpoint = connection.endpoint
+    if endpoint is None or not connection.is_connected():
+        raise ValueError(
+            f"RPC channel for peer {peer_alias!r} requires a connected endpoint. "
+            f"Connection {connection.conn_id} is {connection.state!r}."
+        )
     buf_size = int(getattr(agent, "_rpc_buffer_size", 32_000_000))
     slot_count = int(getattr(agent, "_rpc_max_inflight", 0) or 0)
     if slot_count <= 0:

--- a/dlslime/rpc/service.py
+++ b/dlslime/rpc/service.py
@@ -77,7 +77,7 @@ def serve(
 
     if channel is None:
         if peer is None:
-            peers = agent.get_connected_peers()
+            peers = set(agent.get_connections().keys())
             if len(peers) != 1:
                 raise ValueError(
                     f"serve() with peer=None requires exactly 1 connected peer, "
@@ -424,7 +424,7 @@ def serve_once(
 
     if channel is None:
         if peer is None:
-            peers = agent.get_connected_peers()
+            peers = set(agent.get_connections().keys())
             if len(peers) != 1:
                 raise ValueError(
                     f"serve_once() with peer=None requires exactly 1 peer, "

--- a/docs/design/dlslime-cache.md
+++ b/docs/design/dlslime-cache.md
@@ -129,7 +129,7 @@ Returns the cache service's PeerAgent and cache MR metadata:
   "peer_agent_id": "cache-agent:0",
   "cache_mr_name": "cache",
   "cache_mr_handle": 123,
-  "ctrl": "http://127.0.0.1:3000",
+  "nanoctrl_url": "http://127.0.0.1:3000",
   "scope": null,
   "slab_size": 262144,
   "memory_size": 1073741824,

--- a/examples/python/cache_client_example.py
+++ b/examples/python/cache_client_example.py
@@ -120,7 +120,7 @@ def main() -> None:
         args.length,
     )
 
-    cache_remote_handle = agent.get_remote_handle(server_peer, cache_mr_name)
+    cache_remote_handle = agent.get_handle(cache_mr_name, server_peer)
 
     try:
         stored = client.store(

--- a/examples/python/p2p_rdma_multi_agents_ctrl_plane.py
+++ b/examples/python/p2p_rdma_multi_agents_ctrl_plane.py
@@ -2,7 +2,7 @@
 Example: Multiple Peer Agents using Control Plane (Declarative Topology).
 
 8 agents, mesh network (each agent connects to all others). Measures timing.
-Uses set_desired_topology() and TopologyReconciler for declarative connection setup.
+Uses connect_to() and TopologyReconciler for connection setup.
 """
 
 import contextlib
@@ -71,9 +71,12 @@ def describe_resource(alias, resource):
 
 def print_topology_discovery(observer_alias, observer_agent, aliases):
     print(f"Observer: {observer_alias}")
-    print("Active agents:", observer_agent.query_active_agent())
+    print("Active agents:", observer_agent.list_agents())
     for alias in aliases:
-        resource = observer_agent.query_resource(alias)
+        if alias == observer_alias:
+            resource = observer_agent.get_resource()
+        else:
+            resource = observer_agent.get_resource(alias)
         print(describe_resource(alias, resource))
         if verbose and resource is not None:
             print(json.dumps(resource, indent=2, sort_keys=True))
@@ -95,7 +98,7 @@ with contextlib.ExitStack() as stack:
             # NanoCtrl auto-generates unique name (no alias parameter)
             agent = start_peer_agent(
                 # alias=None (default) - NanoCtrl will auto-generate unique name
-                server_url="http://127.0.0.1:3000",
+                nanoctrl_url="http://127.0.0.1:3000",
             )
             stack.enter_context(agent)  # Auto-cleanup on exit
             # Use allocated name as key
@@ -109,9 +112,9 @@ with contextlib.ExitStack() as stack:
     print("Available peers:")
     print("=" * 60)
     for alias, agent in agents.items():
-        peers = agent.query()
+        peers = agent.list_agents()
         if verbose:
-            print(f"{alias} sees: {list(peers.keys())}")
+            print(f"{alias} sees: {peers}")
 
     print("\n" + "=" * 60)
     print("Topology discovery:")
@@ -119,34 +122,37 @@ with contextlib.ExitStack() as stack:
     observer_alias, observer_agent = next(iter(agents.items()))
     print_topology_discovery(observer_alias, observer_agent, list(agents.keys()))
 
-    # Declarative: set desired topology (mesh - each agent connects to all others)
+    # Connect mesh - each agent connects to all others.
     print("\n" + "=" * 60)
-    print("Setting desired topology (mesh)...")
+    print("Connecting mesh...")
     print("=" * 60)
+    connections = {}
 
-    def set_topology(agent_alias, agent):
+    def connect_agent(agent_alias, agent):
         target_peers = [p for p in agents.keys() if p != agent_alias]
+        agent_connections = []
         for peer in target_peers:
-            agent.set_desired_topology(peer, ib_port=1, qp_num=1)
+            agent_connections.append(agent.connect_to(peer, ib_port=1, qp_num=1))
+        connections[agent_alias] = agent_connections
         if verbose:
             print(f"  {agent_alias}: target_peers={target_peers}")
 
-    with time_measure("set_desired_topology"):
-        run_parallel(agents, set_topology)
+    with time_measure("connect_to"):
+        run_parallel(agents, connect_agent)
 
     # Wait for TopologyReconciler to establish all connections
     print("\n" + "=" * 60)
     print("Waiting for connections (reconciliation)...")
     print("=" * 60)
 
-    def wait_for_peers(agent_alias, agent):
-        target_peers = [p for p in agents.keys() if p != agent_alias]
-        agent.wait_for_peers(target_peers, timeout_sec=30)
+    def wait_connections(agent_alias, agent):
+        for conn in connections[agent_alias]:
+            conn.wait(timeout=30)
         if verbose:
             print(f"  {agent_alias}: all peers connected")
 
-    with time_measure("wait_for_peers"):
-        run_parallel(agents, wait_for_peers)
+    with time_measure("conn.wait"):
+        run_parallel(agents, wait_connections)
 
     # Register memory regions for each agent
     print("\n" + "=" * 60)
@@ -208,7 +214,7 @@ with contextlib.ExitStack() as stack:
             if peer_alias != agent_alias:
                 try:
                     try:
-                        remote_handler = agent.get_remote_handle(peer_alias, "data")
+                        remote_handler = agent.get_handle("data", peer_alias)
                     except RuntimeError:
                         print(f"  {agent_alias} -> {peer_alias}: MR info not found")
                         continue

--- a/examples/python/p2p_rdma_rc_read_ctrl_plane.py
+++ b/examples/python/p2p_rdma_rc_read_ctrl_plane.py
@@ -1,9 +1,9 @@
 """
 Example: P2P RDMA RC Read using Control Plane (Declarative Topology).
 
-Uses the declarative model:
-- set_desired_topology(peer, ...) to declare one directed connection
-- wait_for_peers() blocks until connections are established
+Uses the PeerAgent connection model:
+- connect_to(peer, ...) starts one peer connection
+- conn.wait() blocks until the connection is established
 - PeerAgent.read/write perform I/O through the established endpoint
 """
 
@@ -15,9 +15,12 @@ from dlslime import start_peer_agent
 
 def print_topology_discovery(agent, label, peer_aliases):
     print(f"\nTopology discovery ({label} view):")
-    print("Active agents:", agent.query_active_agent())
+    print("Active agents:", agent.list_agents())
     for alias in peer_aliases:
-        resource = agent.query_resource(alias)
+        if alias == agent.alias:
+            resource = agent.get_resource()
+        else:
+            resource = agent.get_resource(alias)
         print(f"Resource[{alias}]:")
         if resource is None:
             print("  <unavailable>")
@@ -29,12 +32,12 @@ def print_topology_discovery(agent, label, peer_aliases):
 # In a real distributed scenario, these would run on different machines
 initiator_agent = start_peer_agent(
     # alias=None (default) - NanoCtrl will auto-generate unique name
-    server_url="http://127.0.0.1:3000",
+    nanoctrl_url="http://127.0.0.1:3000",
 )
 
 target_agent = start_peer_agent(
     # alias=None (default) - NanoCtrl will auto-generate unique name
-    server_url="http://127.0.0.1:3000",
+    nanoctrl_url="http://127.0.0.1:3000",
 )
 
 # Get allocated names
@@ -43,7 +46,7 @@ target_name = target_agent.alias
 print(f"Allocated names: initiator={initiator_name}, target={target_name}")
 
 # Query available peers
-print("Available peers:", initiator_agent.query())
+print("Available peers:", initiator_agent.list_agents())
 print_topology_discovery(
     initiator_agent,
     "initiator",
@@ -55,14 +58,15 @@ print_topology_discovery(
     [initiator_name, target_name],
 )
 
-# Declarative: set one directed connection; the target accepts it passively.
-print("Setting desired topology...")
-initiator_agent.set_desired_topology(target_name, ib_port=1, qp_num=1)
+# Connect both sides so each agent has a connection handle to wait on.
+print("Connecting peers...")
+initiator_conn = initiator_agent.connect_to(target_name, ib_port=1, qp_num=1)
+target_conn = target_agent.connect_to(initiator_name, ib_port=1, qp_num=1)
 
 # Wait for reconciliation to establish connections
 print("Waiting for connections...")
-initiator_agent.wait_for_peers([target_name])
-target_agent.wait_for_peers([initiator_name])
+initiator_conn.wait()
+target_conn.wait()
 print("Connections established.")
 
 # Register local memory regions (each agent registers its own MR)

--- a/examples/python/rpc_example.py
+++ b/examples/python/rpc_example.py
@@ -37,15 +37,16 @@ class CalcService:
 
 
 def main(ctrl_url: str):
-    worker = PeerAgent(alias="worker:0", server_url=ctrl_url)
+    worker = PeerAgent(nanoctrl_url=ctrl_url, alias="worker:0")
 
     # --- driver agent ---
-    driver = PeerAgent(alias="driver:0", server_url=ctrl_url)
-    driver.set_desired_topology("worker:0", ib_port=1, qp_num=1)
+    driver = PeerAgent(nanoctrl_url=ctrl_url, alias="driver:0")
+    driver_conn = driver.connect_to("worker:0", ib_port=1, qp_num=1)
+    worker_conn = worker.connect_to("driver:0", ib_port=1, qp_num=1)
 
     # wait for both sides to connect
-    driver.wait_for_peers(["worker:0"])
-    worker.wait_for_peers(["driver:0"])
+    driver_conn.wait()
+    worker_conn.wait()
     print("Connected.")
 
     try:

--- a/examples/python/rpc_flatbuf_example.py
+++ b/examples/python/rpc_flatbuf_example.py
@@ -139,15 +139,16 @@ class CalcServiceFB:
 
 def main(ctrl_url: str):
     # --- worker agent ---
-    worker = PeerAgent(alias="worker:0", server_url=ctrl_url)
+    worker = PeerAgent(nanoctrl_url=ctrl_url, alias="worker:0")
 
     # --- driver agent ---
-    driver = PeerAgent(alias="driver:0", server_url=ctrl_url)
-    driver.set_desired_topology("worker:0", ib_port=1, qp_num=1)
+    driver = PeerAgent(nanoctrl_url=ctrl_url, alias="driver:0")
+    driver_conn = driver.connect_to("worker:0", ib_port=1, qp_num=1)
+    worker_conn = worker.connect_to("driver:0", ib_port=1, qp_num=1)
 
     # wait for both sides to connect
-    driver.wait_for_peers(["worker:0"])
-    worker.wait_for_peers(["driver:0"])
+    driver_conn.wait()
+    worker_conn.wait()
     print("Connected.")
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ description = "DLSlime Transfer Engine"
 name = "dlslime"
 readme = "README.md"
 requires-python = ">=3.8"
-version = "0.0.3.rc2"
+version = "0.0.3.rc3"
 dependencies = [
   "pydantic>=2.0",
   "pyzmq>=25.0",

--- a/tests/python/test_cache_python_wrappers.py
+++ b/tests/python/test_cache_python_wrappers.py
@@ -12,26 +12,32 @@ from dlslime.cache import (
 
 class DummyPeerAgent:
     alias = "engine:0"
-    server_url = "http://127.0.0.1:3000"
-    redis_key_prefix = "s0"
+    nanoctrl_url = "http://127.0.0.1:3000"
+    _redis_key_prefix = "s0"
 
     def __init__(self):
         self.connections = []
+
+    class Connection:
+        def __init__(self, owner):
+            self.owner = owner
+
+        def wait(self, timeout=60.0):
+            self.owner.waited = timeout
+            return self
 
     def register_memory_region(self, name, ptr, offset, length):
         self.registered = (name, ptr, offset, length)
         return 123
 
-    def query_resource(self, alias):
+    def get_resource(self):
         return {
             "nics": [{"name": "mlx5_0", "ports": [{"port": 1, "link_type": "RoCE"}]}]
         }
 
-    def set_desired_topology(self, peer_alias, **kwargs):
+    def connect_to(self, peer_alias, **kwargs):
         self.connections.append((peer_alias, kwargs))
-
-    def wait_for_peers(self, peers, timeout_sec=60.0):
-        self.waited = (peers, timeout_sec)
+        return self.Connection(self)
 
 
 def test_cache_service_store_query_splits_slabs():
@@ -89,7 +95,7 @@ def test_cache_service_exposes_peer_agent_info():
     info = service.peer_agent_info()
 
     assert info["peer_agent_id"] == "engine:0"
-    assert info["ctrl"] == "http://127.0.0.1:3000"
+    assert info["nanoctrl_url"] == "http://127.0.0.1:3000"
     assert info["scope"] == "s0"
     assert info["cache_mr_name"] == "cache"
     assert info["cache_mr_handle"] == 123
@@ -155,7 +161,7 @@ def test_cache_client_connects_to_server_peer_agent(monkeypatch):
         assert path == "/peer-agent"
         return {
             "peer_agent_id": "cache-agent:0",
-            "ctrl": "http://127.0.0.1:3000",
+            "nanoctrl_url": "http://127.0.0.1:3000",
             "scope": "s0",
             "cache_mr_name": "cache",
         }
@@ -178,7 +184,7 @@ def test_cache_client_connects_to_server_peer_agent(monkeypatch):
             },
         )
     ]
-    assert peer_agent.waited == (["cache-agent:0"], 3.0)
+    assert peer_agent.waited == 3.0
 
 
 def test_cache_client_reports_peer_agent_restart_hint(monkeypatch):

--- a/tests/python/test_directed_connection_io.py
+++ b/tests/python/test_directed_connection_io.py
@@ -9,6 +9,7 @@ class FakeEndpoint:
         self.read_calls = []
         self.write_calls = []
         self.write_with_imm_calls = []
+        self.send_calls = []
 
     def read(self, assign, stream=None):
         self.read_calls.append((assign, stream))
@@ -21,6 +22,10 @@ class FakeEndpoint:
     def write_with_imm(self, assign, imm_data=0, stream=None):
         self.write_with_imm_calls.append((assign, imm_data, stream))
         return "write-imm-future"
+
+    def send(self, chunk, stream=None):
+        self.send_calls.append((chunk, stream))
+        return "send-future"
 
 
 def _agent(endpoint):
@@ -37,10 +42,10 @@ def _agent(endpoint):
     )
     conn.attach_endpoint(endpoint, memory_pool=None)
     conn.mark_connected()
-    agent._connections = {"peer": conn}
-    agent._connected_peers = {"peer"}
+    agent._connections = {conn.conn_id: conn}
+    agent._connected_peers = {conn.conn_id}
     agent._connected_peers_lock = threading.Lock()
-    agent._endpoints = {"peer": endpoint}
+    agent._endpoints = {conn.conn_id: endpoint}
     agent._endpoints_lock = threading.Lock()
 
     def get_handle(region, peer_alias=None, resource_key=None, endpoint=None):
@@ -80,14 +85,74 @@ def test_query_connection_filters_by_peer_and_nics():
     assert agent.query_connection("peer", local_nic="mlx5_2") is None
 
 
+def test_one_connection_per_nic_pair_allows_multiple_peer_connections():
+    agent = PeerAgent.__new__(PeerAgent)
+    agent.alias = "local"
+    agent._shutdown_called = True
+    agent._connections = {}
+    agent._connections_lock = threading.Lock()
+    local_0 = RdmaResourceKey("mlx5_0", 1, "RoCE")
+    remote_0 = RdmaResourceKey("mlx5_1", 1, "RoCE")
+    local_1 = RdmaResourceKey("mlx5_2", 1, "RoCE")
+    remote_1 = RdmaResourceKey("mlx5_3", 1, "RoCE")
+
+    conn0 = agent._get_or_create_connection(
+        "peer", local_key=local_0, peer_key=remote_0, qp_num=1
+    )
+    conn1 = agent._get_or_create_connection(
+        "peer", local_key=local_1, peer_key=remote_1, qp_num=1
+    )
+
+    assert conn0.conn_id != conn1.conn_id
+    assert set(agent.get_connections()["peer"]) == {conn0.conn_id, conn1.conn_id}
+    assert (
+        agent.query_connection("peer", local_nic="mlx5_0", remote_nic="mlx5_1").conn_id
+        == conn0.conn_id
+    )
+    assert (
+        agent.query_connection("peer", local_nic="mlx5_2", remote_nic="mlx5_3").conn_id
+        == conn1.conn_id
+    )
+    assert (
+        agent.query_connection("peer").conn_id
+        == sorted([conn0.conn_id, conn1.conn_id])[0]
+    )
+
+
+def test_data_plane_selectors_choose_matching_connection():
+    endpoint0 = FakeEndpoint()
+    endpoint1 = FakeEndpoint()
+    agent = _agent(endpoint0)
+    conn1 = DirectedConnection(
+        agent=agent,
+        peer_alias="peer",
+        local_key=RdmaResourceKey("mlx5_2", 1, "RoCE"),
+        peer_key=RdmaResourceKey("mlx5_3", 1, "RoCE"),
+        qp_num=1,
+    )
+    conn1.attach_endpoint(endpoint1, memory_pool=None)
+    conn1.mark_connected()
+    agent._connections[conn1.conn_id] = conn1
+    agent._connected_peers.add(conn1.conn_id)
+    agent._endpoints[conn1.conn_id] = endpoint1
+
+    assert agent.send("peer", "default") == "send-future"
+    assert (
+        agent.send("peer", "selected", local_nic="mlx5_2", remote_nic="mlx5_3")
+        == "send-future"
+    )
+    assert endpoint0.send_calls == [("default", None)]
+    assert endpoint1.send_calls == [("selected", None)]
+
+
 def test_get_endpoint_rejects_mismatched_selectors():
     endpoint = FakeEndpoint()
     agent = _agent(endpoint)
 
-    with pytest.raises(RuntimeError, match="local device"):
+    with pytest.raises(RuntimeError, match="not found"):
         agent._get_endpoint("peer", "mlx5_2", "mlx5_1")
 
-    with pytest.raises(RuntimeError, match="peer device"):
+    with pytest.raises(RuntimeError, match="not found"):
         agent._get_endpoint("peer", "mlx5_0", "mlx5_2")
 
 

--- a/tests/python/test_directed_connection_io.py
+++ b/tests/python/test_directed_connection_io.py
@@ -36,42 +36,59 @@ def _agent(endpoint):
         qp_num=1,
     )
     conn.attach_endpoint(endpoint, memory_pool=None)
+    conn.mark_connected()
     agent._connections = {"peer": conn}
+    agent._connected_peers = {"peer"}
+    agent._connected_peers_lock = threading.Lock()
+    agent._endpoints = {"peer": endpoint}
+    agent._endpoints_lock = threading.Lock()
 
-    def get_local_handle(region, resource_key):
-        assert resource_key == RdmaResourceKey("mlx5_0", 1, "RoCE")
-        return {"kv": 11, "scratch": 12}[region]
-
-    def get_remote_handle(peer, region, resource_key=None, endpoint=None):
-        assert peer == "peer"
+    def get_handle(region, peer_alias=None, resource_key=None, endpoint=None):
+        if peer_alias is None:
+            assert resource_key == RdmaResourceKey("mlx5_0", 1, "RoCE")
+            return {"kv": 11, "scratch": 12}[region]
+        assert peer_alias == "peer"
         assert resource_key == RdmaResourceKey("mlx5_1", 1, "RoCE")
         assert isinstance(endpoint, FakeEndpoint)
         return {"kv": 21, "kv_remote": 22, "remote_scratch": 23}[region]
 
-    agent.get_local_handle = get_local_handle
-    agent.get_remote_handle = get_remote_handle
+    agent.get_handle = get_handle
     return agent
 
 
-def test_query_endpoint_returns_selected_endpoint():
+def test_get_connections_returns_selected_connection():
     endpoint = FakeEndpoint()
     agent = _agent(endpoint)
 
-    assert (
-        agent.query_endpoint("peer", "mlx5_0", "mlx5_1", ib_port=1, qp_num=1)
-        is endpoint
-    )
+    connections = agent.get_connections()
+
+    assert list(connections) == ["peer"]
+    connection = next(iter(connections["peer"].values()))
+    assert connection.endpoint is endpoint
+    assert connection.state == "connected"
+    assert connection.local_nic == "mlx5_0"
+    assert connection.remote_nic == "mlx5_1"
 
 
-def test_query_endpoint_rejects_mismatched_selectors():
+def test_query_connection_filters_by_peer_and_nics():
+    endpoint = FakeEndpoint()
+    agent = _agent(endpoint)
+
+    connection = agent.query_connection("peer", local_nic="mlx5_0", remote_nic="mlx5_1")
+    assert connection is not None
+    assert connection.endpoint is endpoint
+    assert agent.query_connection("peer", local_nic="mlx5_2") is None
+
+
+def test_get_endpoint_rejects_mismatched_selectors():
     endpoint = FakeEndpoint()
     agent = _agent(endpoint)
 
     with pytest.raises(RuntimeError, match="local device"):
-        agent.query_endpoint("peer", "mlx5_2", "mlx5_1")
+        agent._get_endpoint("peer", "mlx5_2", "mlx5_1")
 
     with pytest.raises(RuntimeError, match="peer device"):
-        agent.query_endpoint("peer", "mlx5_0", "mlx5_2")
+        agent._get_endpoint("peer", "mlx5_0", "mlx5_2")
 
 
 def test_peer_agent_read_accepts_named_batches():

--- a/tests/python/test_peer_agent_topology_discovery.py
+++ b/tests/python/test_peer_agent_topology_discovery.py
@@ -8,15 +8,31 @@ from dlslime.peer_agent._agent import PeerAgent, RdmaResourceKey
 
 def _bare_agent(address: str = "10.1.2.3") -> PeerAgent:
     agent = PeerAgent.__new__(PeerAgent)
-    agent.address = address
     agent.alias = "agent_0"
-    agent.redis_key_prefix = ""
-    agent.redis_client = None
+    agent._redis_key_prefix = ""
+    agent._redis_client = None
     agent._logical_regions = {}
     agent._regions_lock = threading.Lock()
     agent._resource_cache = {}
     agent._resource_cache_lock = threading.Lock()
+    agent._local_resource = {
+        "schema_version": 1,
+        "host": {"hostname": address, "address": address},
+        "nics": [],
+        "accelerators": [],
+        "memory_keys": [],
+    }
     agent._shutdown_called = True
+    return agent
+
+
+def _bare_agent_with_connections(*, connected=()):
+    agent = _bare_agent()
+    agent._connections = {"peer": object()}
+    agent._connections_lock = threading.Lock()
+    agent._connected_peers = set(connected)
+    agent._connected_peers_lock = threading.Lock()
+    agent._connected_peers_cond = threading.Condition(agent._connected_peers_lock)
     return agent
 
 
@@ -38,6 +54,21 @@ class FakeRedis:
 
     def ttl(self, key):
         return 30 if key in self.hashes else -2
+
+
+def test_peer_connection_wait_accepts_single_peer():
+    agent = _bare_agent_with_connections(connected={"peer"})
+    conn = peer_agent_mod.PeerConnection(agent, "peer")
+
+    assert conn.wait() is conn
+
+
+def test_peer_connection_wait_rejects_names_without_connection():
+    agent = _bare_agent_with_connections()
+    conn = peer_agent_mod.PeerConnection(agent, "mlx5_0")
+
+    with pytest.raises(ValueError, match="device names belong"):
+        conn.wait(timeout=0.01)
 
 
 def _write(path, text):
@@ -245,41 +276,42 @@ def test_first_usable_resource_key_filters_device_port_and_protocol():
         )
 
 
-def test_publish_resource_record_and_query_resource_round_trip():
+def test_publish_resource_record_and_get_resource_round_trip():
     redis_client = FakeRedis()
     writer = _bare_agent(address="10.0.0.1")
     writer.alias = "agent_0"
-    writer.redis_client = redis_client
+    writer._redis_client = redis_client
     writer._logical_regions = {"attn": object(), "kv": object()}
-    writer._local_resource = {
-        "schema_version": 1,
-        "host": {"hostname": "10.0.0.1", "address": "10.0.0.1"},
-        "nics": [
-            {
-                "name": "mlx5_0",
-                "health": "AVAILABLE",
-                "ports": [{"port": 1, "state": "ACTIVE", "link_type": "RoCE"}],
-            }
-        ],
-        "accelerators": [],
-        "memory_keys": [],
-        "topology_epoch": 123,
-    }
+    writer._local_resource.update(
+        {
+            "nics": [
+                {
+                    "name": "mlx5_0",
+                    "health": "AVAILABLE",
+                    "ports": [{"port": 1, "state": "ACTIVE", "link_type": "RoCE"}],
+                }
+            ],
+            "topology_epoch": 123,
+        }
+    )
 
     writer._publish_resource_record()
 
     reader = _bare_agent(address="10.0.0.2")
     reader.alias = "agent_1"
-    reader.redis_client = redis_client
+    reader._redis_client = redis_client
 
-    assert reader.query_active_agent() == ["agent_0"]
-    assert reader.query_mem_keys("agent_0") == ["attn", "kv"]
+    assert reader.list_agents() == ["agent_0"]
+    assert reader.list_mem_keys("agent_0") == ["attn", "kv"]
 
-    resource = reader.query_resource("agent_0")
+    resource = reader.get_resource("agent_0")
     assert resource is not None
     assert resource["host"]["address"] == "10.0.0.1"
     assert resource["memory_keys"] == ["attn", "kv"]
     assert resource["nics"][0]["name"] == "mlx5_0"
+
+    own_resource = writer.get_resource()
+    assert own_resource is writer._local_resource
     assert resource["nics"][0]["ports"][0]["link_type"] == "RoCE"
 
 

--- a/tests/python/test_peer_agent_topology_discovery.py
+++ b/tests/python/test_peer_agent_topology_discovery.py
@@ -3,7 +3,7 @@ import threading
 import pytest
 from dlslime import discover_topology
 from dlslime.peer_agent import _agent as peer_agent_mod
-from dlslime.peer_agent._agent import PeerAgent, RdmaResourceKey
+from dlslime.peer_agent._agent import DirectedConnection, PeerAgent, RdmaResourceKey
 
 
 def _bare_agent(address: str = "10.1.2.3") -> PeerAgent:
@@ -28,12 +28,19 @@ def _bare_agent(address: str = "10.1.2.3") -> PeerAgent:
 
 def _bare_agent_with_connections(*, connected=()):
     agent = _bare_agent()
-    agent._connections = {"peer": object()}
+    conn = DirectedConnection(
+        agent=agent,
+        peer_alias="peer",
+        local_key=RdmaResourceKey("mlx5_0", 1, "RoCE"),
+        peer_key=RdmaResourceKey("mlx5_1", 1, "RoCE"),
+        qp_num=1,
+    )
+    agent._connections = {conn.conn_id: conn}
     agent._connections_lock = threading.Lock()
-    agent._connected_peers = set(connected)
+    agent._connected_peers = {conn.conn_id for peer in connected if peer == "peer"}
     agent._connected_peers_lock = threading.Lock()
     agent._connected_peers_cond = threading.Condition(agent._connected_peers_lock)
-    return agent
+    return agent, conn.conn_id
 
 
 class FakeRedis:
@@ -57,14 +64,14 @@ class FakeRedis:
 
 
 def test_peer_connection_wait_accepts_single_peer():
-    agent = _bare_agent_with_connections(connected={"peer"})
-    conn = peer_agent_mod.PeerConnection(agent, "peer")
+    agent, conn_id = _bare_agent_with_connections(connected={"peer"})
+    conn = peer_agent_mod.PeerConnection(agent, conn_id)
 
     assert conn.wait() is conn
 
 
 def test_peer_connection_wait_rejects_names_without_connection():
-    agent = _bare_agent_with_connections()
+    agent, _ = _bare_agent_with_connections()
     conn = peer_agent_mod.PeerConnection(agent, "mlx5_0")
 
     with pytest.raises(ValueError, match="device names belong"):

--- a/tests/python/test_rdma_read_offset.py
+++ b/tests/python/test_rdma_read_offset.py
@@ -27,22 +27,23 @@ def test_rdma_read_offset_order():
     # Start two peer agents
     print("\n1. Starting peer agents...")
     agent1 = start_peer_agent(
+        nanoctrl_url="http://127.0.0.1:3000",
         alias="test_agent_1",
-        server_url="http://127.0.0.1:3000",
     )
 
     agent2 = start_peer_agent(
+        nanoctrl_url="http://127.0.0.1:3000",
         alias="test_agent_2",
-        server_url="http://127.0.0.1:3000",
     )
 
     print("   Agents started")
 
-    # Declarative connection
-    print("\n2. Setting desired topology and waiting for connection...")
-    agent1.set_desired_topology("test_agent_2", ib_port=1, qp_num=1)
-    agent1.wait_for_peers(["test_agent_2"])
-    agent2.wait_for_peers(["test_agent_1"])
+    # PeerAgent connection
+    print("\n2. Connecting peers...")
+    conn1 = agent1.connect_to("test_agent_2", ib_port=1, qp_num=1)
+    conn2 = agent2.connect_to("test_agent_1", ib_port=1, qp_num=1)
+    conn1.wait()
+    conn2.wait()
     print("   Connection established")
 
     # Register local buffers
@@ -70,23 +71,16 @@ def test_rdma_read_offset_order():
 
     # Get remote MR info and register
     print("\n4. Registering remote memory regions...")
-    remote_mr_info_1 = agent1.get_mr_info("test_agent_2", "test_buffer")
-    remote_mr_info_2 = agent2.get_mr_info("test_agent_1", "test_buffer")
-
-    remote_mr_1 = agent1.register_remote_memory_region(
-        "test_agent_2", "test_buffer", remote_mr_info_1
-    )
-    remote_mr_2 = agent2.register_remote_memory_region(
-        "test_agent_1", "test_buffer", remote_mr_info_2
-    )
+    remote_mr_1 = agent1.get_handle("test_buffer", "test_agent_2")
+    remote_mr_2 = agent2.get_handle("test_buffer", "test_agent_1")
 
     print(f"   Agent1 remote MR handler: {remote_mr_1}")
     print(f"   Agent2 remote MR handler: {remote_mr_2}")
 
     # Get endpoint
     print("\n5. Getting endpoint...")
-    endpoint_1 = agent1.query_endpoint("test_agent_2")
-    endpoint_2 = agent2.query_endpoint("test_agent_1")
+    endpoint_1 = agent1.query_connection("test_agent_2").endpoint
+    endpoint_2 = agent2.query_connection("test_agent_1").endpoint
     print("   Endpoints obtained")
 
     # Test Case 1: Read from remote offset 0 to local offset 0


### PR DESCRIPTION
## Summary

Refine the `PeerAgent` public API around agents, resources, memory keys, handles, and peer connections.

This PR removes older control-plane/internal-facing API names and reshapes the public surface around clearer user-level concepts:

- `connect_to(...)` returns a `PeerConnection`
- `conn.wait(timeout=...)` waits for that specific connection
- `get_connections()` returns connection objects instead of raw endpoints
- `query_connection(peer, local_nic=..., remote_nic=...)` selects a connection
- `PeerConnection.endpoint` exposes the underlying data-plane endpoint when needed

## Changes

- Rename and simplify PeerAgent read-side APIs:
  - `list_active_agents()` -> `list_agents()`
  - `get_local_resource()` / `get_peer_resource()` -> `get_resource(peer_alias=None)`
  - `list_local_mem_keys()` / `list_peer_mem_keys()` -> `list_mem_keys(peer_alias=None)`
  - `get_local_handle()` / `get_remote_handle()` -> `get_handle(mr_name, peer_alias=None)`

- Replace topology-oriented connection API:
  - `set_desired_topology(...)` -> `connect_to(...)`
  - `wait_for_peers(...)` -> `PeerConnection.wait(...)`

- Add `PeerConnection` facade with:
  - `peer_alias`
  - `conn_id`
  - `state`
  - `local_nic`
  - `remote_nic`
  - `endpoint`
  - `wait()`
  - `is_connected()`

- Replace endpoint-level public lookup:
  - remove `get_endpoints()`
  - add `get_connections()`
  - add `query_connection(...)`

- Support multiple directed connections to the same peer:
  - connection state is keyed by `conn_id`
  - endpoints, connected state, in-flight state, and handshake notification state are tracked per connection
  - one `(local_nic, remote_nic)` pair maps to one connection
  - repeated `connect_to(...)` with the same NIC pair reuses the existing connection
  - different NIC pairs to the same peer can coexist

- Add default-first connection selection:
  - `query_connection("peer")` returns the first stable connection by `conn_id`
  - data-plane wrappers default to the first connection when selectors are omitted
  - callers can pass `local_nic=...` and `remote_nic=...` to select a specific connection

- Extend data-plane wrappers with connection selectors:
  - `read(peer, assign, ..., local_nic=..., remote_nic=...)`
  - `write(peer, assign, ..., local_nic=..., remote_nic=...)`
  - `write_with_imm(peer, assign, ..., local_nic=..., remote_nic=...)`
  - `send(peer, chunk, ..., local_nic=..., remote_nic=...)`
  - `recv(peer, chunk, ..., local_nic=..., remote_nic=...)`
  - `imm_recv(peer, ..., local_nic=..., remote_nic=...)`

- Make PeerAgent internals private where appropriate, including endpoint creation, connection metadata helpers, peer connection state mutation helpers, and remote MR registration.

- Update cache, RPC, examples, and tests to use the new API shape.

## API Example

```python
agent = PeerAgent()

conn = agent.connect_to(
    "agent-df",
    local_device="mlx5_0",
    peer_device="mlx5_0",
)

conn.wait(timeout=30)

endpoint = conn.endpoint
```

Query an existing connection:

```python
conn = agent.query_connection(
    "agent-df",
    local_nic="mlx5_0",
    remote_nic="mlx5_0",
)

endpoint = conn.endpoint
```

Use the default connection:

```python
agent.send("agent-df", chunk)
```

Select a specific NIC pair:

```python
agent.send(
    "agent-df",
    chunk,
    local_nic="mlx5_1",
    remote_nic="mlx5_1",
)
```

## Testing

- `python -m py_compile ...`
- `pytest -q tests/python/test_cache_python_wrappers.py tests/python/test_peer_agent_topology_discovery.py tests/python/test_directed_connection_io.py`

Focused tests pass.
