### PR TITLE
add unregister_mr

### DIFF
--- a/dlslime/csrc/engine/rdma/memory_pool.cpp
+++ b/dlslime/csrc/engine/rdma/memory_pool.cpp
@@ -112,13 +112,61 @@ int RDMAMemoryPool::unregisterMemoryRegion(const uintptr_t& mr_key)
     return 0;
 }
 
+int RDMAMemoryPool::unregisterMemoryRegion(int32_t handle)
+{
+    std::unique_lock<std::mutex> lock(name_mutex_);
+    if (handle < 0 || static_cast<size_t>(handle) >= handle_to_mr_.size() || handle_to_mr_[handle] == nullptr) {
+        SLIME_LOG_WARN("Attempted to unregister non-existent Local MR handle=", handle);
+        return -1;
+    }
+
+    ibv_dereg_mr(handle_to_mr_[handle]);
+    handle_to_mr_[handle] = nullptr;
+
+    for (auto it = name_to_handle_.begin(); it != name_to_handle_.end();) {
+        if (it->second == handle) {
+            it = name_to_handle_.erase(it);
+        }
+        else {
+            ++it;
+        }
+    }
+    for (auto it = ptr_to_handle_.begin(); it != ptr_to_handle_.end();) {
+        if (it->second == handle) {
+            it = ptr_to_handle_.erase(it);
+        }
+        else {
+            ++it;
+        }
+    }
+    return 0;
+}
+
+int RDMAMemoryPool::unregisterMemoryRegion(const std::string& name)
+{
+    int32_t handle = -1;
+    {
+        std::unique_lock<std::mutex> lock(name_mutex_);
+        auto                         it = name_to_handle_.find(name);
+        if (it == name_to_handle_.end()) {
+            SLIME_LOG_WARN("Attempted to unregister non-existent Local MR name=", name);
+            return -1;
+        }
+        handle = it->second;
+    }
+    return unregisterMemoryRegion(handle);
+}
+
 json RDMAMemoryPool::mrInfo()
 {
     std::unique_lock<std::mutex> lock(name_mutex_);
     json                         mr_info;
     for (auto const& [name, handle] : name_to_handle_) {
         struct ibv_mr* mr = handle_to_mr_[handle];
-        mr_info[name]     = {
+        if (mr == nullptr) {
+            continue;
+        }
+        mr_info[name] = {
             {"handle", handle},
             {"addr", (uintptr_t)mr->addr},
             {"rkey", mr->rkey},

--- a/dlslime/csrc/engine/rdma/memory_pool.cpp
+++ b/dlslime/csrc/engine/rdma/memory_pool.cpp
@@ -103,12 +103,18 @@ int32_t RDMAMemoryPool::get_mr_handle(uintptr_t data_ptr)
 int RDMAMemoryPool::unregisterMemoryRegion(const uintptr_t& mr_key)
 {
     std::unique_lock<std::mutex> lock(mrs_mutex_);
-    if (mrs_.count(mr_key)) {
-        ibv_dereg_mr(mrs_[mr_key]);
-        mrs_.erase(mr_key);
+    auto                         it = mrs_.find(mr_key);
+    if (it == mrs_.end() || it->second == nullptr) {
+        SLIME_LOG_WARN("Attempted to unregister non-existent Local MR key=", mr_key);
+        return -1;
     }
-    // Note: We don't currently support unregistering by name or cleaning up handle_to_mr_ easily
-    // without leaving holes, but for this use case (static topology) it's likely fine.
+
+    int rc = ibv_dereg_mr(it->second);
+    if (rc != 0) {
+        SLIME_LOG_ERROR("Failed to unregister Local MR key=", mr_key, ", rc=", rc, ", errno=", errno);
+        return rc;
+    }
+    mrs_.erase(it);
     return 0;
 }
 
@@ -120,7 +126,11 @@ int RDMAMemoryPool::unregisterMemoryRegion(int32_t handle)
         return -1;
     }
 
-    ibv_dereg_mr(handle_to_mr_[handle]);
+    int rc = ibv_dereg_mr(handle_to_mr_[handle]);
+    if (rc != 0) {
+        SLIME_LOG_ERROR("Failed to unregister Local MR handle=", handle, ", rc=", rc, ", errno=", errno);
+        return rc;
+    }
     handle_to_mr_[handle] = nullptr;
 
     for (auto it = name_to_handle_.begin(); it != name_to_handle_.end();) {

--- a/dlslime/csrc/engine/rdma/memory_pool.h
+++ b/dlslime/csrc/engine/rdma/memory_pool.h
@@ -115,6 +115,8 @@ public:
     }
 
     int unregisterMemoryRegion(const uintptr_t& mr_key);
+    int unregisterMemoryRegion(int32_t handle);
+    int unregisterMemoryRegion(const std::string& name);
 
     json mrInfo();
 

--- a/dlslime/csrc/engine/rdma/remote_memory_pool.h
+++ b/dlslime/csrc/engine/rdma/remote_memory_pool.h
@@ -26,16 +26,36 @@ public:
     int32_t registerRemoteMemoryRegion(const std::string& name, const json& mr_info)
     {
         std::unique_lock<std::mutex> lock(mutex_);
-        if (name_to_handle_.count(name)) {
-            SLIME_LOG_INFO("Remote MR Name ", name, " already registered (Handle: ", name_to_handle_[name], ")");
-            return name_to_handle_[name];
-        }
-
-        uintptr_t addr   = mr_info["addr"].get<uintptr_t>();
-        size_t    length = mr_info["length"].get<size_t>();
-        uint32_t  rkey   = mr_info["rkey"].get<uint32_t>();
+        uintptr_t                    addr   = mr_info["addr"].get<uintptr_t>();
+        size_t                       length = mr_info["length"].get<size_t>();
+        uint32_t                     rkey   = mr_info["rkey"].get<uint32_t>();
 
         remote_mr_t mr(addr, length, rkey);
+
+        if (name_to_handle_.count(name)) {
+            int32_t handle = name_to_handle_[name];
+            if (handle >= 0 && static_cast<size_t>(handle) < handle_to_mr_.size()) {
+                remote_mr_t& existing = handle_to_mr_[handle];
+                if (existing.addr != addr || existing.length != length || existing.rkey != rkey) {
+                    existing = mr;
+                    SLIME_LOG_INFO("Updated Remote MR: Name=",
+                                   name,
+                                   ", Handle=",
+                                   handle,
+                                   ", Addr=",
+                                   (void*)addr,
+                                   ", Len=",
+                                   length,
+                                   ", RKey=",
+                                   rkey);
+                }
+                else {
+                    SLIME_LOG_INFO("Remote MR Name ", name, " already registered (Handle: ", handle, ")");
+                }
+                return handle;
+            }
+            SLIME_LOG_WARN("Remote MR Name ", name, " has stale handle ", handle, "; re-registering");
+        }
 
         int32_t handle = handle_to_mr_.size();
         handle_to_mr_.push_back(mr);

--- a/dlslime/csrc/python/bind.cpp
+++ b/dlslime/csrc/python/bind.cpp
@@ -176,6 +176,15 @@ PYBIND11_MODULE(_slime_c, m)
         .def("get_handle",
              static_cast<int32_t (dlslime::RDMAMemoryPool::*)(const std::string&)>(
                  &dlslime::RDMAMemoryPool::get_mr_handle))
+        .def(
+            "unregister_memory_region",
+            [](dlslime::RDMAMemoryPool& self, py::object key) {
+                if (py::isinstance<py::str>(key)) {
+                    return self.unregisterMemoryRegion(key.cast<std::string>());
+                }
+                return self.unregisterMemoryRegion(key.cast<int32_t>());
+            },
+            py::arg("key"))
         .def("mr_info", &dlslime::RDMAMemoryPool::mrInfo);
     py::class_<dlslime::RDMAEndpoint, std::shared_ptr<dlslime::RDMAEndpoint>>(m, "RDMAEndpoint")
         .def(py::init<std::shared_ptr<dlslime::RDMAMemoryPool>, size_t, std::shared_ptr<dlslime::RDMAWorker>>(),

--- a/dlslime/peer_agent/_agent.py
+++ b/dlslime/peer_agent/_agent.py
@@ -1102,6 +1102,7 @@ class PeerAgent:
             return
         with self._regions_lock:
             memory_keys = sorted(self._logical_regions.keys())
+        self._local_resource["memory_keys"] = memory_keys
         try:
             self._redis_client.hset(
                 self._agent_key(self.alias),
@@ -1120,6 +1121,64 @@ class PeerAgent:
             logger.warning(
                 "PeerAgent %s: Memory key publish warning: %s", self.alias, e
             )
+
+    def unregister_memory_region(self, mr_name: str) -> bool:
+        """Unregister a logical memory region and unpublish its materialized keys."""
+        with self._regions_lock:
+            had_logical = self._logical_regions.pop(mr_name, None) is not None
+            materialized = [
+                region
+                for key, region in self._materialized_regions.items()
+                if key[0] == mr_name
+            ]
+            for region in materialized:
+                self._materialized_regions.pop((mr_name, region.resource_key), None)
+
+        for region in materialized:
+            try:
+                _, pool = self._get_context_and_pool(region.resource_key)
+                if hasattr(pool, "unregister_memory_region"):
+                    pool.unregister_memory_region(region.handler)
+            except Exception as e:
+                logger.warning(
+                    "PeerAgent %s: Memory region unregister warning for %s on %s: %s",
+                    self.alias,
+                    mr_name,
+                    region.resource_key,
+                    e,
+                )
+
+        if self._redis_client is not None and self.alias:
+            prefix = self._redis_prefix()
+            mr_key = f"{prefix}mr:{self.alias}:{mr_name}"
+            keys = [mr_key]
+            keys.extend(
+                f"{mr_key}:{region.resource_key.redis_suffix()}"
+                for region in materialized
+            )
+            try:
+                self._redis_client.delete(*keys)
+            except Exception as e:
+                logger.warning(
+                    "PeerAgent %s: Memory region Redis cleanup warning for %s: %s",
+                    self.alias,
+                    mr_name,
+                    e,
+                )
+
+        with self._mr_info_cache_lock:
+            stale_cache_keys = [
+                key
+                for key in self._mr_info_cache
+                if len(key) >= 2 and key[0] == self.alias and key[1] == mr_name
+            ]
+            for key in stale_cache_keys:
+                self._mr_info_cache.pop(key, None)
+
+        if had_logical or materialized:
+            self._publish_memory_keys()
+            return True
+        return False
 
     def _materialize_all_regions_for_key(self, key: RdmaResourceKey) -> None:
         with self._regions_lock:

--- a/dlslime/peer_agent/_agent.py
+++ b/dlslime/peer_agent/_agent.py
@@ -1123,30 +1123,47 @@ class PeerAgent:
             )
 
     def unregister_memory_region(self, mr_name: str) -> bool:
-        """Unregister a logical memory region and unpublish its materialized keys."""
+        """Unregister a local logical memory region.
+
+        This is a local MR lifecycle primitive. The caller must ensure there are
+        no in-flight RDMA operations and no remote peer will continue using a
+        previously published addr/rkey. It does not broadcast invalidation to
+        peers that may have cached old MR metadata.
+        """
         with self._regions_lock:
-            had_logical = self._logical_regions.pop(mr_name, None) is not None
+            had_logical = mr_name in self._logical_regions
             materialized = [
                 region
                 for key, region in self._materialized_regions.items()
                 if key[0] == mr_name
             ]
-            for region in materialized:
-                self._materialized_regions.pop((mr_name, region.resource_key), None)
+
+        if not had_logical and not materialized:
+            return False
 
         for region in materialized:
             try:
                 _, pool = self._get_context_and_pool(region.resource_key)
-                if hasattr(pool, "unregister_memory_region"):
-                    pool.unregister_memory_region(region.handler)
+                if not hasattr(pool, "unregister_memory_region"):
+                    raise RuntimeError(
+                        "underlying memory pool does not support unregister"
+                    )
+                rc = pool.unregister_memory_region(region.handler)
+                if rc != 0:
+                    raise RuntimeError(
+                        "underlying memory pool returned "
+                        f"{rc} for handle {region.handler}"
+                    )
             except Exception as e:
-                logger.warning(
-                    "PeerAgent %s: Memory region unregister warning for %s on %s: %s",
-                    self.alias,
-                    mr_name,
-                    region.resource_key,
-                    e,
-                )
+                raise RuntimeError(
+                    f"Failed to unregister memory region {mr_name!r} on "
+                    f"{region.resource_key}: {e}"
+                ) from e
+
+        with self._regions_lock:
+            self._logical_regions.pop(mr_name, None)
+            for region in materialized:
+                self._materialized_regions.pop((mr_name, region.resource_key), None)
 
         if self._redis_client is not None and self.alias:
             prefix = self._redis_prefix()
@@ -1175,10 +1192,8 @@ class PeerAgent:
             for key in stale_cache_keys:
                 self._mr_info_cache.pop(key, None)
 
-        if had_logical or materialized:
-            self._publish_memory_keys()
-            return True
-        return False
+        self._publish_memory_keys()
+        return True
 
     def _materialize_all_regions_for_key(self, key: RdmaResourceKey) -> None:
         with self._regions_lock:
@@ -1234,11 +1249,14 @@ class PeerAgent:
         peer_alias: str,
         mr_name: str,
         resource_key: Optional[RdmaResourceKey] = None,
+        *,
+        validate_cache: bool = False,
     ) -> Optional[Dict[str, Any]]:
-        """Get remote memory region info (p2p via Redis, persistent cache).
+        """Get remote memory region info (p2p via Redis, local cache).
 
-        MR info is immutable after registration, so cache never expires.
-        Architecture: Redis (source of truth) → PeerAgent cache (0µs hot path).
+        By default this is a cache-first lookup. Transfer paths pass
+        ``validate_cache=True`` so the sender refreshes or invalidates its local
+        cache against Redis immediately before resolving the remote handle.
         """
         cache_key = (
             peer_alias,
@@ -1246,12 +1264,29 @@ class PeerAgent:
             resource_key.redis_suffix() if resource_key else "",
         )
 
-        # Check cache first (fast path: 0µs)
         with self._mr_info_cache_lock:
-            if cache_key in self._mr_info_cache:
-                return self._mr_info_cache[cache_key]
+            cached = self._mr_info_cache.get(cache_key)
+            if cached is not None and not validate_cache:
+                return cached
 
-        # Cache miss: read directly from Redis (p2p, no HTTP)
+        mr_info = self._read_mr_info_from_redis(peer_alias, mr_name, resource_key)
+        if mr_info is None:
+            with self._mr_info_cache_lock:
+                self._mr_info_cache.pop(cache_key, None)
+            return None
+
+        with self._mr_info_cache_lock:
+            if cached is not None and cached == mr_info:
+                return self._mr_info_cache[cache_key]
+            self._mr_info_cache[cache_key] = mr_info
+        return mr_info
+
+    def _read_mr_info_from_redis(
+        self,
+        peer_alias: str,
+        mr_name: str,
+        resource_key: Optional[RdmaResourceKey] = None,
+    ) -> Optional[Dict[str, Any]]:
         prefix = self._redis_prefix()
         mr_key = f"{prefix}mr:{peer_alias}:{mr_name}"
         if resource_key is not None:
@@ -1266,15 +1301,9 @@ class PeerAgent:
             return None
 
         try:
-            mr_info = json.loads(mr_info_str)
+            return json.loads(mr_info_str)
         except json.JSONDecodeError:
             return None
-
-        # Store in cache (persistent, no expiration)
-        with self._mr_info_cache_lock:
-            self._mr_info_cache[cache_key] = mr_info
-
-        return mr_info
 
     def _register_remote_memory_region(
         self,
@@ -1311,7 +1340,12 @@ class PeerAgent:
             key = resource_key or self._default_local_resource_key()
             return self._materialize_region(mr_name, key).handler
 
-        mr_info = self.get_mr_info(peer_alias, mr_name, resource_key=resource_key)
+        mr_info = self.get_mr_info(
+            peer_alias,
+            mr_name,
+            resource_key=resource_key,
+            validate_cache=True,
+        )
         if mr_info is None:
             raise RuntimeError(
                 f"Remote MR '{mr_name}' from peer '{peer_alias}' is not "

--- a/tests/python/test_directed_connection_io.py
+++ b/tests/python/test_directed_connection_io.py
@@ -1,7 +1,13 @@
 import threading
 
 import pytest
-from dlslime.peer_agent._agent import DirectedConnection, PeerAgent, RdmaResourceKey
+from dlslime.peer_agent._agent import (
+    DirectedConnection,
+    LogicalMemoryRegion,
+    MaterializedMemoryRegion,
+    PeerAgent,
+    RdmaResourceKey,
+)
 
 
 class FakeEndpoint:
@@ -26,6 +32,34 @@ class FakeEndpoint:
     def send(self, chunk, stream=None):
         self.send_calls.append((chunk, stream))
         return "send-future"
+
+
+class FakeRedis:
+    def __init__(self):
+        self.values = {}
+        self.hashes = {}
+        self.deleted = []
+
+    def set(self, key, value):
+        self.values[key] = value
+
+    def delete(self, *keys):
+        self.deleted.extend(keys)
+        for key in keys:
+            self.values.pop(key, None)
+            self.hashes.pop(key, None)
+
+    def hset(self, key, mapping):
+        self.hashes.setdefault(key, {}).update(mapping)
+
+
+class FakePool:
+    def __init__(self):
+        self.unregistered = []
+
+    def unregister_memory_region(self, handle):
+        self.unregistered.append(handle)
+        return 0
 
 
 def _agent(endpoint):
@@ -59,6 +93,60 @@ def _agent(endpoint):
 
     agent.get_handle = get_handle
     return agent
+
+
+def test_peer_agent_unregister_memory_region_removes_local_and_published_state():
+    agent = PeerAgent.__new__(PeerAgent)
+    agent.alias = "local"
+    agent._shutdown_called = True
+    agent._redis_key_prefix = ""
+    agent._redis_client = FakeRedis()
+    agent._local_resource = {"memory_keys": ["kv"]}
+    agent._logical_regions = {"kv": LogicalMemoryRegion("kv", 1000, 0, 64)}
+    agent._regions_lock = threading.Lock()
+    agent._mr_info_cache = {
+        ("local", "kv", ""): {"rkey": 1},
+        ("peer", "kv", ""): {"rkey": 2},
+    }
+    agent._mr_info_cache_lock = threading.Lock()
+    key = RdmaResourceKey("mlx5_0", 1, "RoCE")
+    agent._materialized_regions = {
+        ("kv", key): MaterializedMemoryRegion("kv", key, 7, {"rkey": 1})
+    }
+    pool = FakePool()
+    agent._get_context_and_pool = lambda resource_key: (object(), pool)
+
+    base_key = "mr:local:kv"
+    specific_key = "mr:local:kv:mlx5_0:1:RoCE"
+    agent._redis_client.set(base_key, "{}")
+    agent._redis_client.set(specific_key, "{}")
+
+    assert agent.unregister_memory_region("kv") is True
+
+    assert agent._logical_regions == {}
+    assert agent._materialized_regions == {}
+    assert pool.unregistered == [7]
+    assert base_key in agent._redis_client.deleted
+    assert specific_key in agent._redis_client.deleted
+    assert agent._redis_client.values == {}
+    assert agent._mr_info_cache == {("peer", "kv", ""): {"rkey": 2}}
+    assert agent._local_resource["memory_keys"] == []
+    assert agent._redis_client.hashes["agent:local"]["memory_keys"] == "[]"
+
+
+def test_peer_agent_unregister_memory_region_reports_missing_region():
+    agent = PeerAgent.__new__(PeerAgent)
+    agent.alias = "local"
+    agent._shutdown_called = True
+    agent._redis_key_prefix = ""
+    agent._redis_client = None
+    agent._logical_regions = {}
+    agent._materialized_regions = {}
+    agent._regions_lock = threading.Lock()
+    agent._mr_info_cache = {}
+    agent._mr_info_cache_lock = threading.Lock()
+
+    assert agent.unregister_memory_region("missing") is False
 
 
 def test_get_connections_returns_selected_connection():

--- a/tests/python/test_directed_connection_io.py
+++ b/tests/python/test_directed_connection_io.py
@@ -1,3 +1,4 @@
+import json
 import threading
 
 import pytest
@@ -16,6 +17,7 @@ class FakeEndpoint:
         self.write_calls = []
         self.write_with_imm_calls = []
         self.send_calls = []
+        self.remote_register_calls = []
 
     def read(self, assign, stream=None):
         self.read_calls.append((assign, stream))
@@ -33,6 +35,10 @@ class FakeEndpoint:
         self.send_calls.append((chunk, stream))
         return "send-future"
 
+    def register_remote_memory_region(self, name, mr_info):
+        self.remote_register_calls.append((name, mr_info))
+        return 31
+
 
 class FakeRedis:
     def __init__(self):
@@ -42,6 +48,9 @@ class FakeRedis:
 
     def set(self, key, value):
         self.values[key] = value
+
+    def get(self, key):
+        return self.values.get(key)
 
     def delete(self, *keys):
         self.deleted.extend(keys)
@@ -54,12 +63,13 @@ class FakeRedis:
 
 
 class FakePool:
-    def __init__(self):
+    def __init__(self, rc=0):
+        self.rc = rc
         self.unregistered = []
 
     def unregister_memory_region(self, handle):
         self.unregistered.append(handle)
-        return 0
+        return self.rc
 
 
 def _agent(endpoint):
@@ -147,6 +157,80 @@ def test_peer_agent_unregister_memory_region_reports_missing_region():
     agent._mr_info_cache_lock = threading.Lock()
 
     assert agent.unregister_memory_region("missing") is False
+
+
+def test_peer_agent_validates_remote_mr_cache_missing_from_redis():
+    agent = PeerAgent.__new__(PeerAgent)
+    agent.alias = "local"
+    agent._shutdown_called = True
+    agent._redis_key_prefix = ""
+    agent._redis_client = FakeRedis()
+    agent._mr_info_cache = {("peer", "kv", ""): {"addr": 100, "length": 64, "rkey": 1}}
+    agent._mr_info_cache_lock = threading.Lock()
+
+    assert agent.get_mr_info("peer", "kv", validate_cache=True) is None
+    assert agent._mr_info_cache == {}
+
+
+def test_peer_agent_get_handle_validates_and_refreshes_remote_mr_cache():
+    agent = PeerAgent.__new__(PeerAgent)
+    agent.alias = "local"
+    agent._shutdown_called = True
+    agent._redis_key_prefix = ""
+    agent._redis_client = FakeRedis()
+    agent._mr_info_cache = {
+        ("peer", "kv", "mlx5_1:1:RoCE"): {"addr": 100, "length": 64, "rkey": 1}
+    }
+    agent._mr_info_cache_lock = threading.Lock()
+    fresh = {"addr": 200, "length": 128, "rkey": 2}
+    agent._redis_client.set("mr:peer:kv:mlx5_1:1:RoCE", json.dumps(fresh))
+    endpoint = FakeEndpoint()
+
+    handle = agent.get_handle(
+        "kv",
+        "peer",
+        resource_key=RdmaResourceKey("mlx5_1", 1, "RoCE"),
+        endpoint=endpoint,
+    )
+
+    assert handle == 31
+    assert endpoint.remote_register_calls == [("kv", fresh)]
+    assert agent._mr_info_cache == {("peer", "kv", "mlx5_1:1:RoCE"): fresh}
+
+
+def test_peer_agent_unregister_memory_region_keeps_metadata_on_pool_failure():
+    agent = PeerAgent.__new__(PeerAgent)
+    agent.alias = "local"
+    agent._shutdown_called = True
+    agent._redis_key_prefix = ""
+    agent._redis_client = FakeRedis()
+    agent._local_resource = {"memory_keys": ["kv"]}
+    region = LogicalMemoryRegion("kv", 1000, 0, 64)
+    agent._logical_regions = {"kv": region}
+    agent._regions_lock = threading.Lock()
+    agent._mr_info_cache = {("local", "kv", ""): {"rkey": 1}}
+    agent._mr_info_cache_lock = threading.Lock()
+    key = RdmaResourceKey("mlx5_0", 1, "RoCE")
+    materialized = MaterializedMemoryRegion("kv", key, 7, {"rkey": 1})
+    agent._materialized_regions = {("kv", key): materialized}
+    pool = FakePool(rc=-1)
+    agent._get_context_and_pool = lambda resource_key: (object(), pool)
+
+    base_key = "mr:local:kv"
+    specific_key = "mr:local:kv:mlx5_0:1:RoCE"
+    agent._redis_client.set(base_key, "{}")
+    agent._redis_client.set(specific_key, "{}")
+
+    with pytest.raises(RuntimeError, match="underlying memory pool returned -1"):
+        agent.unregister_memory_region("kv")
+
+    assert agent._logical_regions == {"kv": region}
+    assert agent._materialized_regions == {("kv", key): materialized}
+    assert pool.unregistered == [7]
+    assert agent._redis_client.deleted == []
+    assert set(agent._redis_client.values) == {base_key, specific_key}
+    assert agent._mr_info_cache == {("local", "kv", ""): {"rkey": 1}}
+    assert agent._local_resource["memory_keys"] == ["kv"]
 
 
 def test_get_connections_returns_selected_connection():

--- a/tests/python/test_rdma_memory_pool_unregister.py
+++ b/tests/python/test_rdma_memory_pool_unregister.py
@@ -1,0 +1,62 @@
+import ctypes
+
+import pytest
+
+from dlslime import discover_topology, RDMAContext, RDMAMemoryPool
+
+
+def _first_rdma_resource():
+    try:
+        resource = discover_topology(None, 1, None)
+    except RuntimeError as exc:
+        pytest.skip(f"RDMA topology is unavailable: {exc}")
+
+    for nic in resource.get("nics") or []:
+        if nic.get("health", "AVAILABLE") == "UNAVAILABLE":
+            continue
+        for port in nic.get("ports") or []:
+            state = str(port.get("state", "ACTIVE")).upper()
+            if state not in {"ACTIVE", "UNKNOWN"}:
+                continue
+            link_type = str(port.get("link_type") or "RoCE")
+            if link_type.upper() == "UNKNOWN":
+                continue
+            return str(nic["name"]), int(port.get("port", 1)), link_type
+
+    pytest.skip("No usable RDMA resource found")
+
+
+def _memory_pool_or_skip():
+    device, ib_port, link_type = _first_rdma_resource()
+    ctx = RDMAContext()
+    rc = ctx.init(device, ib_port, link_type)
+    if rc != 0:
+        pytest.skip(
+            f"RDMAContext.init failed for {device}:{ib_port}:{link_type} with rc={rc}"
+        )
+    return RDMAMemoryPool(ctx)
+
+
+def test_rdma_memory_pool_unregister_by_handle_and_name():
+    pool = _memory_pool_or_skip()
+    buffer = (ctypes.c_char * 4096)()
+    ptr = ctypes.addressof(buffer)
+
+    handle = pool.register_memory_region(ptr, len(buffer), "kv")
+    assert handle >= 0
+    assert pool.get_handle("kv") == handle
+    assert "kv" in pool.mr_info()
+
+    assert pool.unregister_memory_region(handle) == 0
+    assert pool.get_handle("kv") == -1
+    assert "kv" not in (pool.mr_info() or {})
+    assert pool.unregister_memory_region(handle) != 0
+
+    name_handle = pool.register_memory_region(ptr, len(buffer), "kv-by-name")
+    assert name_handle >= 0
+    assert pool.get_handle("kv-by-name") == name_handle
+
+    assert pool.unregister_memory_region("kv-by-name") == 0
+    assert pool.get_handle("kv-by-name") == -1
+    assert "kv-by-name" not in (pool.mr_info() or {})
+    assert pool.unregister_memory_region("kv-by-name") != 0


### PR DESCRIPTION
## Summary

Add `PeerAgent.unregister_memory_region(name)` and tighten MR lifecycle semantics.

This PR introduces explicit local memory-region unregister support for long-running PeerAgent processes that dynamically register and release Tensor/MR buffers. It also adds transfer-time validation so the peer resolving a remote named MR verifies Redis metadata before using cached MR info.

## Changes

- Add `PeerAgent.unregister_memory_region(name) -> bool`
  - Removes local logical/materialized MR state
  - Deregisters materialized local MR handles
  - Deletes Redis MR metadata
  - Clears local MR cache entries
  - Republishes `memory_keys`

- Add RDMA memory pool unregister support
  - Supports unregister by handle and name
  - Checks `ibv_dereg_mr()` return value
  - Preserves internal mappings if deregistration fails
  - Returns an error for missing/double unregister

- Add transfer-time validation
  - Remote MR cache is validated against Redis when resolving a remote handle
  - Missing Redis metadata invalidates local cache
  - Updated Redis metadata refreshes local cache
  - `RDMARemoteMemoryPool` updates existing remote handles when `addr/length/rkey` changes

- Expose `RDMAMemoryPool.unregister_memory_region(key)` through pybind

- Document semantics in README and README_zh
  - `unregister_memory_region` is a local lifecycle primitive
  - Caller must ensure no in-flight RDMA operations
  - No broadcast invalidation is performed
  - The transfer side validates cached remote MR metadata before use

## Semantics

This PR intentionally does not implement a distributed broadcast invalidation protocol.

Instead, it uses **transfer-time validation**:

> Whoever resolves a remote named memory region for transfer validates its cached MR metadata against Redis before using it.

This keeps invalidation lightweight while avoiding stale `addr/rkey` use after unregister/re-register.

## Tests

Added and updated tests for:

- Successful PeerAgent unregister state cleanup
- Missing region returns `False`
- Pool unregister failure preserves local metadata and Redis state
- Remote MR cache miss invalidates stale cache
- Remote MR Redis update refreshes cached metadata
- RDMA memory pool register/unregister by handle and name through pybind
- Double unregister returns an error

## Verification

```bash
pytest -q tests/python/test_directed_connection_io.py tests/python/test_rdma_memory_pool_unregister.py
python -m py_compile dlslime/peer_agent/_agent.py tests/python/test_directed_connection_io.py tests/python/test_rdma_memory_pool_unregister.py
cmake --build build -j2
